### PR TITLE
Feature - Moderator can approve presentations

### DIFF
--- a/app/Http/Controllers/ContentModeratorController.php
+++ b/app/Http/Controllers/ContentModeratorController.php
@@ -192,6 +192,7 @@ class ContentModeratorController extends Controller
         if ($isApproved) {
             $user = User::find($presentation->mainSpeaker()->user->id);
             $user->speaker->is_approved = 1;
+            $user->assignRole('speaker');
             $user->speaker->save();
 
             Mail::to($presentation->mainSpeaker()->user->email)->send(new PresentationApproved());

--- a/app/Mail/PresentationApproved.php
+++ b/app/Mail/PresentationApproved.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PresentationApproved extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Presentation Approved',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.presentation-approved',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/PresentationDisapproved.php
+++ b/app/Mail/PresentationDisapproved.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PresentationDisapproved extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Presentation Disapproved',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.presentation-disapproved',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -47,4 +47,9 @@ class Presentation extends Model
     {
         return $this->hasMany(Speaker::class);
     }
+
+    public function mainSpeaker()
+    {
+        return $this->speakers()->where('is_main_speaker', 1)->first();
+    }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -16,5 +16,6 @@ class RoleSeeder extends Seeder
         Role::create(['name' => 'participant']);
         Role::create(['name' => 'company representative']);
         Role::create(['name' => 'content moderator']);
+        Role::create(['name' => 'speaker']);
     }
 }

--- a/resources/views/emails/presentation-approved.blade.php
+++ b/resources/views/emails/presentation-approved.blade.php
@@ -1,0 +1,10 @@
+@component('mail::message')
+# Your presentation during the IT Conference got approved!
+
+We are writing to inform you that you will be joining us as a presenter during the conference.
+You will soon get more information about the time and the room in which your presentation will be held!
+
+We are excited to have you on board!
+
+If you did not expect to receive this, you may discard this email.
+@endcomponent

--- a/resources/views/emails/presentation-disapproved.blade.php
+++ b/resources/views/emails/presentation-disapproved.blade.php
@@ -1,0 +1,9 @@
+@component('mail::message')
+We regret to inform you that unfortunately you will not be joining us as a presenter during this year's
+edition of the IT Conference.
+
+We are still looking forward to seeing you there if you sign up for any of the other lectures and workshops
+that are available!
+
+If you did not expect to receive this, you may discard this email.
+@endcomponent

--- a/resources/views/livewire/auth-navigation-menu.blade.php
+++ b/resources/views/livewire/auth-navigation-menu.blade.php
@@ -128,6 +128,27 @@
                                 {{ __('Profile') }}
                             </x-dropdown-link>
 
+                            @role('content moderator')
+                                <div class="border-t border-gray-200 dark:border-gray-600"></div>
+
+                                <div class="block px-4 py-2 text-xs text-gray-400">
+                                    {{ __('Manage requests') }}
+                                </div>
+
+                                <x-dropdown-link href="{{ route('moderator.requests', 'teams') }}">
+                                    {{ __('Company requests') }}
+                                </x-dropdown-link>
+                                <x-dropdown-link href="{{ route('moderator.requests', 'booths') }}">
+                                    {{ __('Booth requests') }}
+                                </x-dropdown-link>
+                                <x-dropdown-link href="{{ route('moderator.requests', 'sponsorships') }}">
+                                    {{ __('Sponsorship requests') }}
+                                </x-dropdown-link>
+                                <x-dropdown-link href="{{ route('moderator.requests', 'presentations') }}">
+                                    {{ __('Presentation requests') }}
+                                </x-dropdown-link>
+                            @endrole
+
                             @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
                                 <x-dropdown-link href="{{ route('api-tokens.index') }}">
                                     {{ __('API Tokens') }}

--- a/resources/views/moderator/details/presentation.blade.php
+++ b/resources/views/moderator/details/presentation.blade.php
@@ -1,0 +1,43 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Presentation details
+        </h2>
+    </x-slot>
+
+    <div>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8 dark:text-gray-200">
+            <h2 class="text-xl">Speaker: {{$presentation->mainSpeaker()->user->name}} </h2>
+            <h2 class="text-md pb-2">{{$presentation->mainSpeaker()->user->currentTeam ? $presentation->mainSpeaker()->user->currentTeam->name : 'Independent speaker' }} </h2>
+            <h2 class="text-lg">Email: <a href="mailto:{{{$presentation->mainSpeaker()->user->email}}}">{{$presentation->mainSpeaker()->user->email}}</a></h2>
+            <x-section-border/>
+            <h2 class="text-xl py-2">Title of presentation: {{$presentation->name}} </h2>
+            <h2 class="text-xl">Description of the presentation:</h2>
+            <p class="text-lg">{{$presentation->description}}</p>
+            <h2 class="text-xl py-2">Type: {{ucfirst($presentation->type)}} </h2>
+            <h2 class="text-xl py-2">Max participants: {{$presentation->max_participants}} </h2>
+            </h2>
+            <x-section-border/>
+            <div>
+                <div class="flex">
+                    <form method="POST" action="{{route('moderator.request.approve', ['presentations', $presentation, 1])}}"
+                          class="mr-2">
+                        @csrf
+                        <x-button
+                            class="dark:bg-green-500 bg-green-500 hover:bg-green-600 hover:dark:bg-green-600 active:bg-green-600 active:dark:bg-green-600">
+                            Approve
+                        </x-button>
+                    </form>
+                    <form method="POST" action="{{ route('moderator.request.approve', ['presentations', $presentation, 0]) }}"
+                          class="mr-2">
+                        @csrf
+                        <x-button
+                            class="dark:bg-red-500 bg-red-500 hover:bg-red-600 hover:dark:bg-red-600 active:bg-red-600 active:dark:bg-red-600">
+                            Disapprove
+                        </x-button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/moderator/requests/presentations.blade.php
+++ b/resources/views/moderator/requests/presentations.blade.php
@@ -1,0 +1,49 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Requests for {{$type}}
+        </h2>
+    </x-slot>
+
+    <div>
+        <div class="max-w-7xl mx-auto py-5 mt-12 sm:px-6 lg:px-8 dark:bg-gray-800 bg-gray-200 rounded">
+            <table class="table-auto w-full ">
+                <thead>
+                <tr>
+                    <th class="px-4 py-2 text-left bg-indigo-500 text-white rounded rounded-r-none">Speaker</th>
+                    <th class="px-4 py-2 text-left bg-indigo-500 text-white rounded rounded-r-none rounded-l-none">
+                        Presentation title
+                    </th>
+                    <th class="px-4 py-2 text-left bg-indigo-500 text-white rounded rounded-l-none">Type</th>
+                </tr>
+                </thead>
+                <tbody>
+                @foreach($presentations as $index => $presentation)
+                    <tr class="{{ $index % 2 === 0 ? 'dark:bg-gray-900 bg-gray-100' : 'dark:bg-gray-700 bg-gray-200' }} dark:text-gray-200">
+                        <td class="px-4 py-5 rounded rounded-t-none text-lg rounded-r-none">
+                            <a href="{{route('moderator.request.details', ['presentations', $presentation])}}">
+                                {{$presentation->mainSpeaker()->user->name}}
+                            </a>
+                        </td>
+                        <td class="px-4 py-5 rounded rounded-t-none text-lg rounded-r-none rounded-l-none">
+                            <a href="{{route('moderator.request.details', ['presentations', $presentation])}}">
+                                {{$presentation->name}}
+                            </a>
+                        </td>
+                        <td class="px-4 py-5 rounded rounded-t-none text-lg rounded-l-none">
+                            <a href="{{route('moderator.request.details', ['presentations', $presentation])}}">
+                                {{ucfirst($presentation->type)}}
+                            </a>
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</x-app-layout>
+<style>
+    td a {
+        display: block;
+    }
+</style>


### PR DESCRIPTION
As the moderator already can approve booths, companies and sponsorship, this introduces approval of presentations

For testing:
- [x] The temp navigation in the dropdown is working (it's not responsive)
- [x] The moderator can approve the presentation request (the is_approved in speakers = true)
- [x] The moderator can disapprove the presentation request (the relevant entity in speakers and presentations deleted)