### PR TITLE
Feature - Content moderator can manually add companies

### DIFF
--- a/app/Actions/Jetstream/CreateTeam.php
+++ b/app/Actions/Jetstream/CreateTeam.php
@@ -2,12 +2,18 @@
 
 namespace App\Actions\Jetstream;
 
+use App\Mail\CustomTeamInvitation;
+use App\Mail\InviteCompany;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Events\AddingTeam;
+use Laravel\Jetstream\Events\InvitingTeamMember;
 use Laravel\Jetstream\Jetstream;
 
 class CreateTeam implements CreatesTeams
@@ -15,29 +21,46 @@ class CreateTeam implements CreatesTeams
     /**
      * Validate and create a new team for the given user.
      *
-     * @param  array<string, string>  $input
+     * @param array<string, string> $input
      */
     public function create(User $user, array $input): Team
     {
-        Gate::forUser($user)->authorize('create', Jetstream::newTeamModel());
+        if (!$user->hasRole('content moderator')) {
+            abort(403);
+        }
 
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
-            'company_name' => 'required',
-            'company_description' => 'required',
-            'company_website' => 'required',
-            'company_address' => 'required',
+            'name' => 'required',
+            'description' => 'required',
+            'website' => 'required',
+            'address' => 'required',
+            'rep_name' => 'required',
+            'rep_email' => 'required'
         ])->validateWithBag('createTeam');
 
-        AddingTeam::dispatch($user);
+        $user = User::create([
+            'name' => $input['rep_name'],
+            'email' => $input['rep_email'],
+            'password' => Hash::make(fake()->password)]);
 
-        $user->switchTeam($team = $user->ownedTeams()->create([
-            'name' => $input['company_name'],
-            'address' => $input['company_address'],
-            'website' => $input['company_website'],
-            'description' => $input['company_description'],
+        $user->assignRole('company representative');
+
+        $team = Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => $input['name'],
+            'address' => $input['address'],
+            'website' => $input['website'],
+            'description' => $input['description'],
             'personal_team' => false,
-        ]));
+            'is_approved' => true,
+        ]);
+
+        // Reusing the default team invitation
+        $invitation = $team->teamInvitations()->create([
+            'email' => $user->email,
+            'role' => 'company representative',
+        ]);
+        Mail::to($user->email)->send(new InviteCompany($invitation));
 
         return $team;
     }

--- a/app/Mail/InviteCompany.php
+++ b/app/Mail/InviteCompany.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\URL;
+use Laravel\Jetstream\TeamInvitation;
+
+class InviteCompany extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * The team invitation instance.
+     *
+     * @var TeamInvitation
+     */
+    public $invitation;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param TeamInvitation $invitation
+     * @return void
+     */
+    public function __construct(TeamInvitation $invitation)
+    {
+        $this->invitation = $invitation;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->markdown('emails.invite-company-rep', ['acceptUrl' => URL::signedRoute('company-rep.invitation', [
+            'invitation' => $this->invitation,
+        ])])->subject(__('Participation in the IT Conference'));
+    }
+}

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -31,7 +31,7 @@ class TeamPolicy
      */
     public function create(User $user): bool
     {
-        return true;
+        return $user->hasRole('content moderator');
     }
 
     /**

--- a/resources/views/auth/company-rep-invitation.blade.php
+++ b/resources/views/auth/company-rep-invitation.blade.php
@@ -1,0 +1,41 @@
+<x-app-layout>
+    <x-authentication-card>
+        <x-slot name="logo">
+            <h1 class="text-gray-800 dark:text-white text-3xl font-bold text-center pt-12">
+                We are in IT together</br>Conference
+            </h1>
+        </x-slot>
+
+        <x-validation-errors class="mb-4" />
+
+        <form method="POST" action="{{ route('company-rep.registration', $invitation) }}">
+            @csrf
+
+            <div class="block">
+                <x-label for="email" value="{{ __('Email') }}" />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" readonly :value="$invitation->team->owner->email" required autofocus autocomplete="username" />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="name" value="{{ __('Name') }}" />
+                <x-input id="name" class="block mt-1 w-full" type="text" name="name" readonly :value="$invitation->team->owner->name" required autofocus autocomplete="username" />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="password" value="{{ __('Password') }}" />
+                <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="password_confirmation" value="{{ __('Confirm Password') }}" />
+                <x-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <x-button>
+                    {{ __('Continue') }}
+                </x-button>
+            </div>
+        </form>
+    </x-authentication-card>
+</x-app-layout>

--- a/resources/views/emails/invite-company-rep.blade.php
+++ b/resources/views/emails/invite-company-rep.blade.php
@@ -1,0 +1,18 @@
+@component('mail::message')
+# You have been invited to join the IT Conference!
+
+Hello {{$invitation->team->owner->name}}!
+
+You have been invited to join the IT Conference as a company representative of {{$invitation->team->name}}.
+
+As a company representative you will be able to add and remove employees that will be joining you during the conference,
+send enquires about sponsorship, booth.
+
+To gain access to the system as a company representative you just need to follow the link and change your password.
+
+@component('mail::button', ['url' => $acceptUrl])
+Join the IT Conference
+@endcomponent
+
+If you did not expect to receive an invitation to this team, you may discard this email.
+@endcomponent

--- a/resources/views/teams/create-team-form.blade.php
+++ b/resources/views/teams/create-team-form.blade.php
@@ -1,30 +1,46 @@
 <x-form-section submit="createTeam">
     <x-slot name="title">
-        {{ __('Team Details') }}
+        {{ __('Company Details') }}
     </x-slot>
 
     <x-slot name="description">
-        {{ __('Create a new team to collaborate with others on projects.') }}
+        {{ __('Add manually a new company that will join the conference. An email with invitation to join as company rep will be sent on the company representative email you specify bellow') }}
     </x-slot>
 
     <x-slot name="form">
-        <div class="col-span-6">
-            <x-label value="{{ __('Team Owner') }}" />
-
-            <div class="flex items-center mt-2">
-                <img class="w-12 h-12 rounded-full object-cover" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}">
-
-                <div class="ml-4 leading-tight">
-                    <div class="text-gray-900 dark:text-white">{{ $this->user->name }}</div>
-                    <div class="text-gray-700 dark:text-gray-300 text-sm">{{ $this->user->email }}</div>
-                </div>
-            </div>
-        </div>
-
         <div class="col-span-6 sm:col-span-4">
-            <x-label for="name" value="{{ __('Team Name') }}" />
-            <x-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="state.name" autofocus />
-            <x-input-error for="name" class="mt-2" />
+            <x-label for="name" value="{{ __('Company Name') }}"/>
+            <x-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="state.name" autofocus/>
+            <x-input-error for="name" class="mt-2"/>
+        </div>
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="description" value="{{ __('Company Description') }}"/>
+            <textarea id="description" wire:model.defer="state.description"
+                      class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm block mt-1 w-full"
+                      name="description" required
+            >{{old('company_description')}}</textarea>
+        </div>
+        <!-- TODO: Once the company address is fixed with proper fields, refactor here and in the CreateTeam class -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="address" value="{{ __('Company Address') }}"/>
+            <x-input id="address" type="text" class="mt-1 block w-full" wire:model.defer="state.address" autofocus/>
+            <x-input-error for="address" class="mt-2"/>
+        </div>
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="website" value="{{ __('Company Website') }}"/>
+            <x-input id="website" type="text" class="mt-1 block w-full" wire:model.defer="state.website" autofocus/>
+            <x-input-error for="website" class="mt-2"/>
+        </div>
+        <div class="col-span-6 sm:col-span-4">
+            <x-section-border />
+            <x-label for="rep_name" value="{{ __('Company Representative Name') }}"/>
+            <x-input id="rep_name" type="text" class="mt-1 block w-full" wire:model.defer="state.rep_name" autofocus/>
+            <x-input-error for="rep_name" class="mt-2"/>
+        </div>
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="rep_email" value="{{ __('Company Representative Email') }}"/>
+            <x-input id="rep_email" type="email" class="mt-1 block w-full" wire:model.defer="state.rep_email" autofocus/>
+            <x-input-error for="rep_email" class="mt-2"/>
         </div>
     </x-slot>
 

--- a/resources/views/teams/create.blade.php
+++ b/resources/views/teams/create.blade.php
@@ -1,7 +1,8 @@
 <x-app-layout>
+    <!-- TODO: Once the new content moderator layout is approved, refactor the design -->
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ __('Create Team') }}
+            {{ __('Add a company') }}
         </h2>
     </x-slot>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,11 @@ Route::get('/register/team-invitations/{invitation}', [InvitationController::cla
 Route::post('/register/team-invitations/{invitation}', [InvitationController::class, 'register'])
     ->name('register.via.invitation');
 
+Route::get('/company-representative-invitation/{invitation}', [InvitationController::class, 'companyRepShow'])
+    ->middleware(['signed'])->name('company-rep.invitation');
+Route::post('/company-representative-invitation/{invitation}', [InvitationController::class, 'companyRepStore'])
+    ->name('company-rep.registration');
+
 Route::get('/faq', function () {
     return view('faq');
 })->name('faq');


### PR DESCRIPTION
Allows the content moderator to manually add companies. When the moderator fills in the details needed for the company and the email and name of the company rep, a user with the role company rep is created and put as the owner of the team, because teams cannot have empty owner. A mail is sent to the company rep's email and there after following the link they need to change their password to gain access to the account. 
For testing:
- [x] Content moderator can reach /teams/create
- [x] After submitting the data a team is created and a user, the user being owner (company rep) of the team
- [x] Invitation is created in the db and a mail with it sent to the email given for the company rep
- [x] The link in the email leads to a page that prompts you to change the password (the link is signed so try to change the url to see if it works properly)
- [x] After changing the pass user is redirected to the default page (currently myhub)


In future updates for better security we can play around with tokens instead of password but it's just an idea.