### PR TITLE
Feature - Reject all sponsorship requests when max sponsors is reached

### DIFF
--- a/app/Http/Controllers/ContentModeratorController.php
+++ b/app/Http/Controllers/ContentModeratorController.php
@@ -170,6 +170,9 @@ class ContentModeratorController extends Controller
         if ($isApproved) {
             $team->is_sponsor_approved = true;
             $team->save();
+            if($team->sponsorTier->leftSpots() == 0)
+                $team->sponsorTier->rejectAllExceptApproved();
+
             Mail::to($team->owner->email)->send(new SponsorshipApproved($team));
 
             $message = __('You approved the sponsorship of :company!', ['company' => $team->name]);

--- a/app/Http/Livewire/SponsorshipRequest.php
+++ b/app/Http/Livewire/SponsorshipRequest.php
@@ -15,7 +15,14 @@ class SponsorshipRequest extends Component
     {
         $this->team = $team;
         $this->tiers = $tiers;
-        $this->chosenTierName = 'golden';
+        foreach ($tiers as $tier)
+        {
+            if($tier->leftSpots() > 0)
+            {
+                $this->chosenTierName = $tier->name;
+                break;
+            }
+        }
 
         $this->requestSent = (bool)$this->team->sponsorTier;
     }

--- a/app/Models/SponsorTier.php
+++ b/app/Models/SponsorTier.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Mail\SponsorshipDisapproved;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Mail;
 
 class SponsorTier extends Model
 {
@@ -21,11 +23,28 @@ class SponsorTier extends Model
 
     public function areMoreSponsorsAllowed()
     {
-        return $this->teams()->where('is_sponsor_approved','=', 1)->count() < $this->max_sponsors;
+        return $this->teams()->where('is_sponsor_approved', '=', 1)->count() < $this->max_sponsors;
     }
 
     public function leftSpots()
     {
-        return $this->max_sponsors - $this->teams()->where('is_sponsor_approved','=', 1)->count();
+        return $this->max_sponsors - $this->teams()->where('is_sponsor_approved', '=', 1)->count();
+    }
+
+    /**
+     * Reject all companies that have requested this sponsorship but are not approved
+     * @return void
+     */
+    public function rejectAllExceptApproved()
+    {
+        foreach ($this->teams as $team) {
+            if (!$team->is_sponsor_approved) {
+                Mail::to($team->owner->email)->send(new SponsorshipDisapproved($team));
+
+                $team->sponsor_tier_id = null;
+                $team->is_sponsor_approved = null;
+                $team->save();
+            }
+        }
     }
 }

--- a/resources/views/livewire/sponsorship-request.blade.php
+++ b/resources/views/livewire/sponsorship-request.blade.php
@@ -20,7 +20,7 @@
 
             <!-- Tiers -->
             <div class="col-span-6 sm:col-span-4">
-                @if(!$this->requestSent)
+                @if(!$this->requestSent && !is_null($chosenTierName))
                     <div class="col-span-6 lg:col-span-4">
                         <x-label for="tier" value="{{ __('Sponsor tier') }}"/>
                         <div
@@ -47,6 +47,8 @@
                                 You are approved and confirmed as a {{ucfirst($this->team->sponsorTier->name)}} sponsor!
                             </div>
                         </div>
+                    @elseif(is_null($chosenTierName))
+                        There is no more space for sponsors
                     @else
                         <div class="row">
                             <div class="mt-4 text-amber-500 dark:text-amber-400 py-2 text-left rounded">
@@ -66,7 +68,7 @@
         </x-slot>
 
         <x-slot name="actions">
-            @if(!$this->requestSent)
+            @if(!$this->requestSent && !is_null($chosenTierName))
                 <x-button>
                     {{ __('Send request') }}
                 </x-button>


### PR DESCRIPTION
For testing
- [x] When a content mod approves a sponsor if the tier is full of sponsors, all other request for the tier are rejected
- [x] When there is no place for sponsors, users are not allowed to send requests