### PR TITLE
Feature - Multiple speakers from the same company

### DIFF
--- a/app/Http/Controllers/ContentModeratorController.php
+++ b/app/Http/Controllers/ContentModeratorController.php
@@ -24,6 +24,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Mail;
 
+// TODO: All status changes need to be refactored in events
 class ContentModeratorController extends Controller
 {
     /**
@@ -189,10 +190,7 @@ class ContentModeratorController extends Controller
     {
         $message = '';
         if ($isApproved) {
-            $user = User::find($presentation->mainSpeaker()->user->id);
-            $user->speaker->is_approved = 1;
-            $user->assignRole('speaker');
-            $user->speaker->save();
+            $presentation->approve();
 
             Mail::to($presentation->mainSpeaker()->user->email)->send(new PresentationApproved());
 

--- a/app/Http/Controllers/SpeakerController.php
+++ b/app/Http/Controllers/SpeakerController.php
@@ -34,12 +34,23 @@ class SpeakerController extends Controller
         $presentation =
             Presentation::create($request->validate(Presentation::rules()));
 
-        Speaker::create([
-            'user_id' => Auth::user()->id,
-            'presentation_id' => $presentation->id,
-            'is_main_speaker' => 1,
-            'is_approved' => 0,
-        ]);
+        if (Auth::user()->currentTeam) {
+            foreach (Auth::user()->currentTeam->allSpeakers as $speaker) {
+                Speaker::create([
+                    'user_id' => $speaker->id,
+                    'presentation_id' => $presentation->id,
+                    'is_main_speaker' => Auth::user()->id == $speaker->id ? 1 : 0,
+                    'is_approved' => 0,
+                ]);
+            }
+        } else {
+            Speaker::create([
+                'user_id' => Auth::user()->id,
+                'presentation_id' => $presentation->id,
+                'is_main_speaker' => 1,
+                'is_approved' => 0,
+            ]);
+        }
 
         return redirect(route('welcome'))->banner("You successfully send your request to host a {$presentation->type}");
     }

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -106,10 +106,21 @@ class Presentation extends Model
      *
      * @return int
      */
-    public function maxParticipants() : int
+    public function maxParticipants(): int
     {
         return $this->room->max_participants < $this->max_participants
             ? $this->room->max_participants
             : $this->max_participants;
+    }
+
+    /**
+     * Called in order to approve the speakers connected to the presentation
+     * @return void
+     */
+    public function approve()
+    {
+        foreach ($this->speakers as $speaker) {
+            $speaker->approve();
+        }
     }
 }

--- a/app/Models/Speaker.php
+++ b/app/Models/Speaker.php
@@ -29,4 +29,15 @@ class Speaker extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Approves the speaker and makes it a global speaker
+     * @return void
+     */
+    public function approve() : void
+    {
+        $this->is_approved = 1;
+        $this->user->assignRole('speaker');
+        $this->save();
+    }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -106,7 +106,7 @@ class Team extends JetstreamTeam
                         $presentations[] = $user->speaker->presentation()->get();
                     }
 
-                    return collect($presentations)->unique();
+                    return collect($presentations)->flatten();
                 }
 
                 return null;

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -80,6 +80,18 @@ class Team extends JetstreamTeam
     }
 
     /**
+     * All the speakers that are within a team, even though they may not
+     * be approved globally
+     * @return Attribute
+     */
+    public function allSpeakers(): Attribute
+    {
+        return Attribute::make(
+            get: fn() => $this->users()->wherePivot('role', 'speaker')->get(),
+        );
+    }
+
+    /**
      * All the presentations that the team has. All teams should have only one but
      * the gold sponsor.
      * @return Attribute

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -66,22 +67,54 @@ class Team extends JetstreamTeam
         return $this->hasOne(Booth::class);
     }
 
-    public function speakers()
+    /**
+     * All the speakers that are in the team and are approved.
+     * (Approved means that they have a global (spatie) role speaker)
+     * @return Attribute
+     */
+    public function speakers(): Attribute
     {
-        return $this->users()->wherePivot('role', 'speaker')->get();
+        return Attribute::make(
+            get: fn() => $this->users()->role('speaker')->get(),
+        );
     }
 
-    public function presentation()
+    /**
+     * All the presentations that the team has. All teams should have only one but
+     * the gold sponsor.
+     * @return Attribute
+     */
+    public function presentations(): Attribute
     {
-        if($this->speakers()->count() != 0)
-        {
-            $user = $this->speakers()->first(function ($user) {
-                return $user->speaker !== null;
-            });
+        return Attribute::make(
+            get: function () {
+                if ($this->speakers->count() != 0) {
+                    $presentations = [];
+                    foreach ($this->speakers as $user) {
+                        $presentations[] = $user->speaker->presentation()->get();
+                    }
 
-            return !is_null($user) ? $user->speaker->presentation : null;
-        }
+                    return collect($presentations)->unique();
+                }
 
-        return null;
+                return null;
+            }
+        );
+    }
+
+    /**
+     * Checks if currently there is a pending request for a presentation
+     * by the team
+     * @return Attribute
+     */
+    public function hasPendingPresentationRequest(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                return $this->users()->whereHas('speaker', function ($query) {
+                    $query->where('is_approved', 0)->where('is_main_speaker', 1);
+                })->wherePivot('role', 'speaker')->exists();
+            }
+        );
     }
 }

--- a/app/Policies/PresentationPolicy.php
+++ b/app/Policies/PresentationPolicy.php
@@ -20,8 +20,9 @@ class PresentationPolicy
     {
         return is_null($user->speaker)
             && (is_null($user->currentTeam)
-                || (is_null($user->currentTeam->presentation())
+                || (is_null($user->currentTeam->presentations)
                     && ($user->hasTeamRole($user->currentTeam, 'speaker')
-                        && $user->currentTeam->owner->id !== $user->id)));
+                        && $user->currentTeam->owner->id !== $user->id
+                        && !$user->hasRole('speaker'))));
     }
 }

--- a/tests/Feature/PasswordConfirmationTest.php
+++ b/tests/Feature/PasswordConfirmationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class PasswordConfirmationTest extends TestCase
@@ -12,6 +13,7 @@ class PasswordConfirmationTest extends TestCase
 
     public function test_confirm_password_screen_can_be_rendered(): void
     {
+        Role::create(['name' => 'speaker']);
         $user = User::factory()->withPersonalTeam()->create();
 
         $response = $this->actingAs($user)->get('/user/confirm-password');


### PR DESCRIPTION
Some changes were made on the Team model, because during the meeting before summer break it came up that the gold sponsor will have two presentations. Refactoring approvals for the presentations.

For testing:
- [ ] When company rep invites two speakers, and both register before requesting presentation, whoever requests the presentation becomes the the main speaker, the other one is therefore not - check table speakers to make sure. Both will have prop is_approved to false until it's approved by content mod
- [ ] When company rep invites two speakers, one of them registers and requests a presentation, then the other one registers the second one is also added to the speakers table with is_approved = 0
- [ ] When company rep invites two speakers, one of them registers, requests a presentation and the presentation is approved, then the other one registers the second one is also added to the speakers table with is_approved = 1
- [ ] When no presentation is requested or approved, the speakers should not be in speakers table
- [ ] Only when their is_approved changes to true, they should immediately get spatie role of 'speaker' reffer to model_has_roles
- [ ] The policy about who can request a presentation works
- [ ] The refactoring/new paths is not breaking the independent presentation requests

If there's time refer to the failed build and check why in a test that has nothing to do with roles and spatie, a missing 'speaker' spatie role error is thrown.