### PR TITLE
Feature - Allow content moderator to override the difficulty level

### DIFF
--- a/app/Http/Livewire/OverrideDifficulty.php
+++ b/app/Http/Livewire/OverrideDifficulty.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+
+class OverrideDifficulty extends Component
+{
+    public $presentation;
+    public $selectedDifficultyId;
+
+    protected $rules = [
+        'selectedDifficultyId' => 'required'
+    ];
+
+    public function mount($presentation)
+    {
+        $this->presentation = $presentation;
+        $this->selectedDifficultyId = $presentation->difficulty->id;
+    }
+
+    public function updateDifficulty()
+    {
+        $this->presentation->update([
+            'difficulty_id' => $this->selectedDifficultyId
+        ]);
+
+        session()->flash('message', 'The difficulty level is successfully updated.');
+    }
+
+    public function render()
+    {
+        return view('livewire.override-difficulty');
+    }
+}

--- a/resources/views/livewire/override-difficulty.blade.php
+++ b/resources/views/livewire/override-difficulty.blade.php
@@ -1,0 +1,26 @@
+<div>
+    <form wire:submit.prevent="updateDifficulty">
+        @csrf
+        <div class="pb-3 pr-7">
+            <label for="room">Select difficulty level:</label>
+            <select name="difficulty_selector" wire:model="selectedDifficultyId"
+                    class="mt-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-indigo-500 focus:border-indigo-500 block w-full p-2.5 dark:bg-gray-900 dark:border-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-indigo-500 dark:focus:border-indigo-500">
+                @foreach (\App\Models\Difficulty::all() as $difficulty)
+                    @if($presentation->difficulty->id == $difficulty->id)
+                        <option selected value="{{ $difficulty->id }}">{{ ucfirst($difficulty->level) }}</option>
+                    @else
+                        <option value="{{ $difficulty->id }}">{{ ucfirst($difficulty->level) }}</option>
+                    @endif
+                @endforeach
+            </select>
+        </div>
+        <button class="bg-indigo-800 hover:bg-indigo-700 text-white py-2 px-4 rounded">
+            Save
+        </button>
+        @if (session()->has('message'))
+            <div class="text-sm text-green-600">
+                {{ session('message') }}
+            </div>
+        @endif
+    </form>
+</div>

--- a/resources/views/moderator/schedule/presentation-schedule.blade.php
+++ b/resources/views/moderator/schedule/presentation-schedule.blade.php
@@ -22,7 +22,10 @@
             <p class="text-lg">{{$presentation->description}}</p>
             <h2 class="text-lg py-2">Type: {{ucfirst($presentation->type)}} </h2>
             <h2 class="text-lg py-2">Max participants that the speaker wants: {{$presentation->max_participants}} </h2>
-            </h2>
+            <x-section-border/>
+            <div>
+                @livewire('override-difficulty', ['presentation' => $presentation])
+            </div>
         </div>
         <div>
             <div>


### PR DESCRIPTION
A single and simple livewire component that updates the difficulty level of a presentation from the moderator view of the presentation (the `presentation-schedule`).

For testing:
- [ ] The component is shown in the `presentation-schedule`
- [ ] The component shows the current difficulty level
- [ ] When saved, the difficulty level of the presentation actually updates

When the PR with notifications get approved will add notification for the speaker that his presentation's been updated.