### PR TITLE
Feature - Upload presentation

### DIFF
--- a/app/Http/Livewire/HelperUploadPresentation.php
+++ b/app/Http/Livewire/HelperUploadPresentation.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class HelperUploadPresentation extends Component
+{
+    use WithFileUploads;
+
+    public $file;
+    public $path;
+
+    public function render()
+    {
+        return view('livewire.helper-upload-presentation');
+    }
+
+    public function updatedFile()
+    {
+        $this->validate([
+            'file' => ['required',
+                'file',
+                'max:10240',
+                'mimetypes:application/pdf,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            ],
+        ], [
+            'file.required' => 'The file is required',
+            'file.max' => 'The file must not be larger than 10MB',
+            'file.mimetypes' => 'The file must be a pdf, powerpoint, or presentation document',
+        ]);
+
+        Storage::delete('presentations' . explode('@', Auth::user()->email)[0] . '-presentation');
+        $this->path = $this->file->storeAs('presentations', explode('@', Auth::user()->email)[0] . '-presentation');
+        session()->flash('message', 'Presentation is successfully added.');
+    }
+}

--- a/app/Http/Livewire/UploadPresentation.php
+++ b/app/Http/Livewire/UploadPresentation.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use App\Models\Presentation;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class UploadPresentation extends Component
+{
+    use WithFileUploads;
+
+    public $file;
+    public $presentation;
+
+    public function mount($presentation)
+    {
+        $this->presentation = $presentation;
+    }
+
+    public function updatedFile()
+    {
+        $this->validate([
+            'file' => ['required',
+                'file',
+                'max:10240',
+                'mimetypes:application/pdf,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            ]
+        ], [
+            'file.required' => 'The file is required',
+            'file.max' => 'The file must not be larger than 10MB',
+            'file.mimetypes' => 'The file must be a pdf, powerpoint, or presentation document',
+        ]);
+    }
+
+    public function downloadFile()
+    {
+        return Storage::download($this->presentation->file_path);
+    }
+
+    public function save()
+    {
+        $this->validate([
+            'file' => ['required',
+                'file',
+                'max:10240',
+                'mimetypes:application/pdf,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            ],
+        ], [
+            'file.required' => 'The file is required',
+            'file.max' => 'The file must not be larger than 10MB',
+            'file.mimetypes' => 'The file must be a pdf, powerpoint, or presentation document',
+        ]);
+
+        Storage::delete('presentations' . explode('@', Auth::user()->email)[0] . '-presentation');
+        $path = $this->file->storeAs('presentations', explode('@', Auth::user()->email)[0] . '-presentation');
+        $this->presentation->file_path = $path;
+        $this->presentation->save();
+        session()->flash('message', 'Presentation is successfully updated.');
+    }
+
+    public function render()
+    {
+        return view('livewire.upload-presentation');
+    }
+}

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -13,7 +13,7 @@ class Presentation extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'max_participants', 'description', 'type', 'difficulty_id'];
+    protected $fillable = ['name', 'max_participants', 'description', 'type', 'difficulty_id', 'file_path'];
 
     public static function rules()
     {
@@ -22,7 +22,8 @@ class Presentation extends Model
             'max_participants' => 'required|numeric',
             'description' => 'required',
             'type' => 'required|in:workshop,lecture',
-            'difficulty_id' => 'required'
+            'difficulty_id' => 'required',
+            'file_path' => 'required'
         ];
     }
 

--- a/database/factories/PresentationFactory.php
+++ b/database/factories/PresentationFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Presentation>
@@ -16,11 +18,15 @@ class PresentationFactory extends Factory
      */
     public function definition(): array
     {
+        $file = UploadedFile::fake()->create($this->faker->word . '.pdf', 100);
+        $path = Storage::disk('local')->putFile('test-data', $file);
+
         return [
             'name' => $this->faker->name,
             'description' => $this->faker->paragraph,
             'max_participants' => $this->faker->numberBetween(1, 50),
             'type' => $this->faker->boolean ? 'lecture' : 'workshop',
+            'file_path' => $path
         ];
     }
 }

--- a/database/migrations/2023_09_01_103220_update_presentations_table_with_file_path.php
+++ b/database/migrations/2023_09_01_103220_update_presentations_table_with_file_path.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('presentations', function (Blueprint $table) {
+            $table->string('file_path', 2048)->nullable('false');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('presentations', function (Blueprint $table) {
+            $table->dropColumn('file_path');
+        });
+    }
+};

--- a/resources/views/livewire/helper-upload-presentation.blade.php
+++ b/resources/views/livewire/helper-upload-presentation.blade.php
@@ -1,0 +1,19 @@
+<div class="col-span-6 sm:col-span-4">
+    <x-label for="file" value="Upload the presentation slides"/>
+    <input type="text" name="file_path" value="{{$path}}" class="hidden">
+    <input type="file" id="file" wire:model="file"
+           class="hidden">
+    <label for="file"
+           class="flex items-center justify-center w-1/3 h-10 px-4 mt-2 text-sm font-medium text-white bg-indigo-600 rounded-md cursor-pointer hover:bg-indigo-700 focus-within:bg-indigo-700">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+             stroke="currentColor" class="w-6 h-6 mr-2">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+        </svg>
+        Upload a file
+    </label>
+    <div class="text-sm text-green-600">
+        {{ session('message') }}
+    </div>
+    @error('file') <p class="mt-2 text-sm text-red-600">{{ $message }}</p> @enderror
+</div>

--- a/resources/views/livewire/upload-presentation.blade.php
+++ b/resources/views/livewire/upload-presentation.blade.php
@@ -1,0 +1,59 @@
+@php use Illuminate\Support\Facades\Auth; @endphp
+<div>
+    <form wire:submit.prevent="save" class="space-y-8">
+        <div class="space-y-8 divide-y divide-gray-200">
+            <div class="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
+                <div class="sm:col-span-6">
+                    <x-label for="photo" value="{{ __('Presentation') }}"/>
+                    @if ($presentation->file_path)
+                        <x-label for="preview" value="{{ __('Current presentation') }}" class="pt-3 pb-1"/>
+                        <p wire:click="downloadFile" style="cursor: pointer;">
+                            <span class="text-blue-600">
+                                {{ basename($presentation->file_path) }}
+                            </span>
+                        </p>
+                        @if (session()->has('message'))
+                            <div class="text-sm text-green-600">
+                                {{ session('message') }}
+                            </div>
+                        @endif
+                    @endif
+                    @if(Auth::user()->hasRole('speaker'))
+                        @if(Auth::user()->speaker->presentation_id == $presentation->id)
+                            <div class="mt-1 flex items-center">
+                                <input type="file" id="file" wire:model="file"
+                                       class="hidden">
+                                <label for="file"
+                                       class="flex items-center justify-center w-1/3 h-10 px-4 mt-2 text-sm font-medium text-white bg-indigo-600 rounded-md cursor-pointer hover:bg-indigo-700 focus-within:bg-indigo-700">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                         stroke="currentColor" class="w-6 h-6 mr-2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                              d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                                    </svg>
+                                    @if($presentation->file_path)
+                                        Change file
+                                    @else
+                                        Upload file
+                                    @endif
+                                </label>
+                            </div>
+                        @endif
+                    @endif
+                    @error('file') <p class="mt-2 text-sm text-red-600">{{ $message }}</p> @enderror
+                </div>
+            </div>
+        </div>
+        @if(Auth::user()->hasRole('speaker'))
+            @if(Auth::user()->speaker->presentation_id == $presentation->id)
+                <div class="pt-5">
+                    <div class="flex justify-end">
+                        <button type="submit"
+                                class="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            Save
+                        </button>
+                    </div>
+                </div>
+            @endif
+        @endif
+    </form>
+</div>

--- a/resources/views/moderator/schedule/presentation-schedule.blade.php
+++ b/resources/views/moderator/schedule/presentation-schedule.blade.php
@@ -23,6 +23,8 @@
             <h2 class="text-lg py-2">Type: {{ucfirst($presentation->type)}} </h2>
             <h2 class="text-lg py-2">Max participants that the speaker wants: {{$presentation->max_participants}} </h2>
             </h2>
+            <x-section-border/>
+            @livewire('upload-presentation', ['presentation' => $presentation])
         </div>
         <div>
             <div>

--- a/resources/views/speakers/presentation-request.blade.php
+++ b/resources/views/speakers/presentation-request.blade.php
@@ -51,6 +51,7 @@
                         <x-input id="max_participants" name="max_participants" type="number" class="mt-1 block w-full"/>
                         <x-input-error for="max_participants" class="mt-2"/>
                     </div>
+                    @livewire('helper-upload-presentation')
                     <x-button
                         class="mt-5 dark:bg-green-500 bg-green-500 hover:bg-green-600 hover:dark:bg-green-600 active:bg-green-600 active:dark:bg-green-600">
                         Submit


### PR DESCRIPTION
Two components developed in order to upload presentation - one in the presentation request and one for upload and view (used in the moderator view for now, will be moved to the presentation show)

For testing:
- [ ] Speaker can only upload pdf and powerpoint
- [ ] Speaker cannot request a presentation if the slides are not uploaded
- [ ] Moderator can only see the presentation slides, they cannot edit them

A lot of UI and UX work on this one.