### PR TITLE
Fix - Bug when requesting presentation as independent speaker

### DIFF
--- a/app/Http/Controllers/SpeakerController.php
+++ b/app/Http/Controllers/SpeakerController.php
@@ -33,10 +33,12 @@ class SpeakerController extends Controller
 
     public function processRequest(Request $request)
     {
-        if (Auth::user()->currentTeam->owner->id === Auth::user()->id) {
-            Auth::user()->currentTeam->users()->attach(
-                Auth::user(), ['role' => 'speaker']
-            );
+        if (Auth::user()->team) {
+            if (Auth::user()->currentTeam->owner->id === Auth::user()->id) {
+                Auth::user()->currentTeam->users()->attach(
+                    Auth::user(), ['role' => 'speaker']
+                );
+            }
         }
 
         $presentation =


### PR DESCRIPTION
When requesting as independent speaker (without company) an error was thrown because it couldn't find the company. Introduces a fix