### PR TITLE
Hotfix - Company logo update permissions

### DIFF
--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -81,4 +81,12 @@ class TeamPolicy
     {
         return $user->ownsTeam($team);
     }
+
+    /**
+     * Determine whether the user can change the logo of the company.
+     */
+    public function changeLogo(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
 }

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -23,9 +23,10 @@
 
             <div>
                 <div class="py-10">
-                    @livewire('manage-company-logo', ['team' => $team])
-
-                    <x-section-border/>
+                    @can('changeLogo', Auth::user()->currentTeam)
+                        @livewire('manage-company-logo', ['team' => $team])
+                        <x-section-border/>
+                    @endcan
 
                     @livewire('teams.update-team-name-form', ['team' => $team])
 


### PR DESCRIPTION
This branch introduces fix to issue #201. Now only the company rep should be able to change the logo of the company