### PR TITLE
Fix - Automatically confirm email when company rep is invited and signs in

### DIFF
--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -138,6 +138,7 @@ class InvitationController extends Controller
     public function companyRepStore(Request $request, TeamInvitation $invitation)
     {
         (new ResetUserPassword())->reset($invitation->team->owner, $request->all());
+        $invitation->team->owner->email_verified_at = now()->timestamp;
         $this->guard->login($invitation->team->owner);
 
         $invitation->team->owner->switchTeam($invitation->team);


### PR DESCRIPTION
Since the invitation is happening through the mail it seems unnecessarily to make them verify the email from which they registered.

Closes #252 