### PR TITLE
Rework - Remove schedule lunch break

### DIFF
--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -157,7 +157,7 @@ class ScheduleController extends Controller
         foreach ($presentations as $presentation) {
             $timeslots = Timeslot::where('duration', $presentation->type == 'lecture' ? 30 : 90)
                 ->get();
-            $rooms = (new RoomController())->getRoomsWithClosestCapacity(12);
+            $rooms = Room::getWithClosestCapacity($presentation->max_participants);
 
             $availableCombination = $rooms->crossJoin($timeslots)
                 ->first(function ($room_timeslot) {

--- a/app/Http/Controllers/TimeslotController.php
+++ b/app/Http/Controllers/TimeslotController.php
@@ -34,28 +34,12 @@ class TimeslotController extends Controller
             'ending' => 'required|date_format:H:i|after:starting',
         ];
 
-        if ($request->all()['breakStart'])
-            $rules['breakStart'] = 'date_format:H:i|after:starting|before:ending';
-
-        if ($request->all()['breakEnd'])
-            $rules['breakEnd'] = 'date_format:H:i|after:breakStart|before:ending';
-
         $validatedData = $request->validate($rules);
 
         $starting = $validatedData['starting'];
         $ending = $validatedData['ending'];
-        $breakStart = key_exists('breakStart', $validatedData) ? $validatedData['breakStart'] : '12:30';
-        $breakEnd = key_exists('breakEnd', $validatedData) ? $validatedData['breakEnd'] : '13:00';
 
-        if($breakEnd < $breakStart)
-        {
-            return redirect(route('moderator.schedule.timeslots.create'))
-                ->withInput()
-                ->withErrors(['breakEnd' => 'The ending time of the break cannot be before the starting time']);
-        }
-
-        $this->generate($starting, $breakStart);
-        $this->generate($breakEnd, $ending);
+        $this->generate($starting, $ending);
 
         if (Room::all()->count() == 0) {
             return redirect(route('rooms.index'));

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -53,4 +53,17 @@ class Room extends Model
     {
         return $this->hasMany(Presentation::class);
     }
+
+    /**
+     * List with the rooms with the closest capacity to the maximum participants passed
+     * @param $maxCapacity
+     * @return mixed
+     */
+    public static function getWithClosestCapacity($maxCapacity)
+    {
+        return Room::select('*')
+            ->selectRaw('CAST(max_participants AS SIGNED) AS signed_capacity')
+            ->orderByRaw('ABS(signed_capacity - ?)', [$maxCapacity])
+            ->get();
+    }
 }

--- a/database/factories/PresentationFactory.php
+++ b/database/factories/PresentationFactory.php
@@ -26,7 +26,8 @@ class PresentationFactory extends Factory
             'description' => $this->faker->paragraph,
             'max_participants' => $this->faker->numberBetween(1, 50),
             'type' => $this->faker->boolean ? 'lecture' : 'workshop',
-            'file_path' => $path
+            'file_path' => $path,
+            'difficulty_id' => $this->faker->numberBetween(1, 3),
         ];
     }
 }

--- a/resources/views/moderator/schedule/timeslots-create.blade.php
+++ b/resources/views/moderator/schedule/timeslots-create.blade.php
@@ -31,20 +31,6 @@
                          class="mt-1 block w-full"/>
                 <x-input-error for="ending" class="mt-2"/>
             </div>
-            <hr>
-            <h3 class="text-lg text-gray-900 dark:text-white pt-5">Lunch break</h3>
-            <div class="col-span-6 sm:col-span-4 pt-5">
-                <x-label for="breakStart" value="Starting time of lunch break (default is 12:30)"/>
-                <x-input id="breakStart" name="breakStart" type="time" value="{{old('breakStart')}}"
-                         class="mt-1 block w-full"/>
-                <x-input-error for="breakStart" class="mt-2"/>
-            </div>
-            <div class="col-span-6 sm:col-span-4 py-4">
-                <x-label for="breakEnd" value="Ending time of lunch break (default is 13:00)"/>
-                <x-input id="breakEnd" name="breakEnd" type="time" value="{{old('breakEnd')}}"
-                         class="mt-1 block w-full"/>
-                <x-input-error for="breakEnd" class="mt-2"/>
-            </div>
             <x-button
                 class="mt-5 dark:bg-green-500 bg-green-500 hover:bg-green-600 hover:dark:bg-green-600 active:bg-green-600 active:dark:bg-green-600">
                 Save


### PR DESCRIPTION
Closes #291 and #285

Also as well caught that one of the methods for room allocation was missing (`getWithClosestCapacity`), added it again but this time in the `Room` model and fixed the param that was passed to this method, because until now, the param was a const instead of the actual number of participants that the speaker has put as max participants