### PR TITLE
Fix - Issue when creating a booth with empty additional info

### DIFF
--- a/app/Http/Controllers/ContentModerator/BoothController.php
+++ b/app/Http/Controllers/ContentModerator/BoothController.php
@@ -40,6 +40,8 @@ class BoothController extends Controller
         ]);
 
         $input['is_approved'] = 1;
+        if (is_null($input['additional_information']))
+            $input['additional_information'] = 'No additional demands';
 
         $booth = Booth::create($input);
 


### PR DESCRIPTION
Added a check if the the additional info when booth is created is empty and setting a default value. Closes #294 