### PR TITLE
Hotfix - Push presentation request/edit deadline to 27th of October

### DIFF
--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -195,7 +195,9 @@ class Presentation extends Model
     protected function speakerCanEdit() : Attribute
     {
         $currentDate = Carbon::now();
-        $deadline = Carbon::createFromDate($currentDate->year, 10, 12);
+        $deadline = Carbon::createFromDate($currentDate->year, 10, 27);
+        $deadline->setTime(12, 0, 0);
+        $deadline->setTimezone('Europe/Amsterdam');
 
         return Attribute::make(
             get: fn() => $currentDate->lt($deadline)

--- a/app/Policies/PresentationPolicy.php
+++ b/app/Policies/PresentationPolicy.php
@@ -20,7 +20,9 @@ class PresentationPolicy
     public function request(User $user): bool
     {
         $currentDate = Carbon::now();
-        $deadline = Carbon::createFromDate($currentDate->year, 10, 12);
+        $deadline = Carbon::createFromDate($currentDate->year, 10, 27);
+        $deadline->setTime(12, 0, 0);
+        $deadline->setTimezone('Europe/Amsterdam');
 
         // If the deadline for the 12th of October has passed
         if ($currentDate->gt($deadline)) {


### PR DESCRIPTION
Initially we thought that deadline is the 12th so currently no one can request/edit presentations. The hotfix moves the deadline to **27th of October, 12:00**. 