### PR TITLE
Fix - Negative max participants

### DIFF
--- a/app/Http/Controllers/PresentationController.php
+++ b/app/Http/Controllers/PresentationController.php
@@ -25,6 +25,9 @@ class PresentationController extends Controller
     {
         $this->authorize('request', Presentation::class);
 
+        $presentation =
+            Presentation::create($request->validate(Presentation::rules()));
+
         if (Auth::user()->currentTeam) {
             if (Auth::user()->currentTeam->owner->id === Auth::user()->id) {
                 Auth::user()->currentTeam->users()->attach(
@@ -32,9 +35,6 @@ class PresentationController extends Controller
                 );
             }
         }
-
-        $presentation =
-            Presentation::create($request->validate(Presentation::rules()));
 
         Auth::user()->setRelations([]);
 

--- a/app/Http/Livewire/EditPresentationModal.php
+++ b/app/Http/Livewire/EditPresentationModal.php
@@ -20,7 +20,7 @@ class EditPresentationModal extends Component
 
     protected $rules = [
         'name' => 'required',
-        'max_participants' => 'required|numeric',
+        'max_participants' => 'required|numeric|min:1',
         'description' => 'required',
         'type' => 'required|in:workshop,lecture',
         'difficulty_id' => 'required|numeric',

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -61,7 +61,7 @@ class Presentation extends Model
     {
         return [
             'name' => 'required',
-            'max_participants' => 'required|numeric',
+            'max_participants' => 'required|numeric|min:1',
             'description' => 'required',
             'type' => 'required|in:workshop,lecture',
             'difficulty_id' => 'required',


### PR DESCRIPTION
Closes #298 

Caught also another issue - if the company rep was the one who requested the presentation, if the validation failed the first time, and try to submit again it would lead to error because the record was already added in `team_user`. Fixed it