### PR TITLE
Fix countdown not showing when navigating between pages (#413)

### DIFF
--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -3,7 +3,7 @@
 
 @push('scripts')
         <script>
-            document.addEventListener("DOMContentLoaded", function() {
+            document.addEventListener('livewire:navigated', () => {
                 const countDownDate = new Date("Nov 15, 2024 9:00:00").getTime();
                 const timeUnits = ['months', 'days', 'hours', 'minutes', 'seconds'];
                 let valueElements = [];
@@ -59,6 +59,6 @@
                     }
 
                 }, 1000);
-            });
+            }, { once: true });
     </script>
 @endpush


### PR DESCRIPTION
# Description
Fix for the countdown disappearing when navigating between pages and then returning to the homepage.

closes #413 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] Navigate between different frontpages and check if the countdown stays.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

