### PR TITLE
Feature - Programme release prerequisites 

### DIFF
--- a/app/Http/Controllers/Crew/ScheduleController.php
+++ b/app/Http/Controllers/Crew/ScheduleController.php
@@ -21,7 +21,9 @@ class ScheduleController extends Controller
      */
     public function index(): View
     {
-        return view('crew.schedule.index');
+        $noActiveEdition = is_null(Edition::current());
+
+        return view('crew.schedule.index', compact(['noActiveEdition']));
     }
 
     /**

--- a/app/Http/Controllers/Crew/ScheduleController.php
+++ b/app/Http/Controllers/Crew/ScheduleController.php
@@ -8,8 +8,12 @@ use App\Models\DefaultPresentation;
 use App\Models\Edition;
 use App\Models\Event;
 use App\Models\Presentation;
+use App\Models\Sponsorship;
 use App\Models\Timeslot;
+use App\Policies\SchedulePolicy;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 class ScheduleController extends Controller
@@ -21,6 +25,10 @@ class ScheduleController extends Controller
      */
     public function index(): View
     {
+        if (!Gate::authorize('view-schedule')) {
+            abort(403);
+        }
+
         $noActiveEdition = is_null(Edition::current());
 
         return view('crew.schedule.index', compact(['noActiveEdition']));
@@ -36,6 +44,10 @@ class ScheduleController extends Controller
      */
     public function reset($type)
     {
+        if (!Gate::authorize('edit-schedule')) {
+            abort(403);
+        }
+
         Presentation::query()->update([
             'room_id' => null,
             'timeslot_id' => null,
@@ -62,6 +74,10 @@ class ScheduleController extends Controller
      */
     public function publishFinalProgramme()
     {
+        if (!Gate::authorize('edit-schedule')) {
+            abort(403);
+        }
+
         $readyForRelease = Presentation::all()->every(function ($presentation) {
             return $presentation->isScheduled && $presentation->is_approved;
         });

--- a/app/Http/Controllers/Crew/ScheduleController.php
+++ b/app/Http/Controllers/Crew/ScheduleController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers\Crew;
 
+use App\Events\FinalProgrammeReleased;
 use App\Http\Controllers\Controller;
 use App\Models\DefaultPresentation;
+use App\Models\Edition;
+use App\Models\Event;
 use App\Models\Presentation;
 use App\Models\Timeslot;
 use Illuminate\Http\Request;
@@ -48,5 +51,18 @@ class ScheduleController extends Controller
 
         return redirect(route('moderator.schedule.index'))
             ->banner('You reset the schedule successfully.');
+    }
+
+    /**
+     * Changes the state of the edition to enrollment
+     *
+     * @return void
+     */
+    public function publishFinalProgramme()
+    {
+        FinalProgrammeReleased::dispatch();
+
+        return redirect(route('moderator.schedule.index'))
+            ->banner('The programme was published successfully! Participants now can enroll in the presentations');
     }
 }

--- a/app/Http/Controllers/Crew/ScheduleController.php
+++ b/app/Http/Controllers/Crew/ScheduleController.php
@@ -62,6 +62,16 @@ class ScheduleController extends Controller
      */
     public function publishFinalProgramme()
     {
+        $readyForRelease = Presentation::all()->every(function ($presentation) {
+            return $presentation->isScheduled && $presentation->is_approved;
+        });
+
+        if (!$readyForRelease) {
+            return redirect(route('moderator.schedule.index'))
+                ->banner('Seems like the programme cannot be released yet. Check the status of the presentation');
+        }
+
+
         FinalProgrammeReleased::dispatch();
 
         return redirect(route('moderator.schedule.index'))

--- a/app/Livewire/Schedule/AddDefaultPresentation.php
+++ b/app/Livewire/Schedule/AddDefaultPresentation.php
@@ -9,6 +9,7 @@ use App\Models\Timeslot;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Livewire\Component;
 use LivewireUI\Modal\ModalComponent;
@@ -39,6 +40,8 @@ class AddDefaultPresentation extends ModalComponent
      */
     public function save()
     {
+        $this->authorize('edit-schedule');
+
         $this->form->save();
 
         if ($this->form->isEntityCreated()) {

--- a/app/Livewire/Schedule/Cell.php
+++ b/app/Livewire/Schedule/Cell.php
@@ -145,6 +145,8 @@ class Cell extends Component
     public function refresh()
     {
         $timeslotStart = Carbon::parse($this->timeslot->start);
+        $this->room = $this->room->fresh();
+
         $this->presentations = $this->room->presentations()
             ->where('start', '>=', $timeslotStart)
             ->where('start', '<', $timeslotStart->copy()->addMinutes($this->timeslot->duration))

--- a/app/Livewire/Schedule/EditDefaultPresentationModal.php
+++ b/app/Livewire/Schedule/EditDefaultPresentationModal.php
@@ -8,6 +8,7 @@ use App\Models\Room;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Livewire\Component;
 use LivewireUI\Modal\ModalComponent;
@@ -25,6 +26,8 @@ class EditDefaultPresentationModal extends ModalComponent
      */
     public function mount($type)
     {
+        $this->authorize('edit-schedule');
+
         $this->type = $type;
         $this->rooms = Room::all();
         $this->form->setType($this->type);

--- a/app/Livewire/Schedule/GridParentComponent.php
+++ b/app/Livewire/Schedule/GridParentComponent.php
@@ -76,6 +76,13 @@ class GridParentComponent extends Component
         $this->dispatch("check-programme-status");
     }
 
+    /**
+     * Responsible for handling the removing of presentation
+     * from the schedule
+     *
+     * @param $data
+     * @return void
+     */
     #[On('remove-presentation')]
     public function removeScheduledPresentation($data)
     {

--- a/app/Livewire/Schedule/GridParentComponent.php
+++ b/app/Livewire/Schedule/GridParentComponent.php
@@ -16,6 +16,8 @@ class GridParentComponent extends Component
     public $rooms;
     public $timeslots;
     public $unscheduledPresentations;
+    public $lectureCount;
+    public $workshopCount;
 
     /**
      * Initializes the component
@@ -27,8 +29,11 @@ class GridParentComponent extends Component
         $this->timeslots = Timeslot::all();
 
         $this->unscheduledPresentations = Presentation::where(function ($presentation) {
-            return $presentation->whereNull(['timeslot_id', 'room_id']);
-        })->get();
+            return $presentation->whereNull(['timeslot_id', 'room_id', 'start']);
+        })->get()->where('is_approved', '=', 1);
+
+        $this->lectureCount = $this->unscheduledPresentations->where('type', 'lecture')->count();
+        $this->workshopCount = $this->unscheduledPresentations->where('type', 'workshop')->count();
     }
 
     /**
@@ -56,10 +61,12 @@ class GridParentComponent extends Component
             $this->dispatch("update-cell-r-{$oldRoom->id}-t-{$oldTimeslot->id}");
         } else {
             $this->unscheduledPresentations = Presentation::where(function ($presentation) {
-                return $presentation->whereNull(['timeslot_id', 'room_id']);
-            })->get();
+                return $presentation->whereNull(['timeslot_id', 'room_id', 'start']);
+            })->get()->where('is_approved', '=', 1);
         }
 
+        $this->lectureCount = $this->unscheduledPresentations->where('type', 'lecture')->count();
+        $this->workshopCount = $this->unscheduledPresentations->where('type', 'workshop')->count();
         $this->dispatch("update-cell-r-{$presentation->room->id}-t-{$presentation->timeslot->id}");
     }
 

--- a/app/Livewire/Schedule/GridParentComponent.php
+++ b/app/Livewire/Schedule/GridParentComponent.php
@@ -27,7 +27,16 @@ class GridParentComponent extends Component
     {
         $this->rooms = Room::all();
         $this->timeslots = Timeslot::all();
+        $this->refreshUnscheduledPresentations();
+    }
 
+    /**
+     * Fetches the data for the unscheduled presentations from the database
+     *
+     * @return void
+     */
+    public function refreshUnscheduledPresentations()
+    {
         $this->unscheduledPresentations = Presentation::where(function ($presentation) {
             return $presentation->whereNull(['timeslot_id', 'room_id', 'start']);
         })->get()->where('is_approved', '=', 1);
@@ -60,19 +69,37 @@ class GridParentComponent extends Component
         if ($oldRoom && $oldTimeslot) {
             $this->dispatch("update-cell-r-{$oldRoom->id}-t-{$oldTimeslot->id}");
         } else {
-            $this->unscheduledPresentations = Presentation::where(function ($presentation) {
-                return $presentation->whereNull(['timeslot_id', 'room_id', 'start']);
-            })->get()->where('is_approved', '=', 1);
+            $this->refreshUnscheduledPresentations();
         }
 
-        $this->lectureCount = $this->unscheduledPresentations->where('type', 'lecture')->count();
-        $this->workshopCount = $this->unscheduledPresentations->where('type', 'workshop')->count();
         $this->dispatch("update-cell-r-{$presentation->room->id}-t-{$presentation->timeslot->id}");
+        $this->dispatch("check-programme-status");
+    }
+
+    #[On('remove-presentation')]
+    public function removeScheduledPresentation($data)
+    {
+        $presentation = Presentation::find($data['presentation_id']);
+        $oldRoomId = $presentation->room_id;
+        $oldTimeslotId = $presentation->timeslot_id;
+
+        $presentation->update([
+            'start' => null
+        ]);
+        $presentation->room()->dissociate();
+        $presentation->timeslot()->dissociate();
+        $presentation->save();
+        $presentation->refresh();
+
+        $this->refreshUnscheduledPresentations();
+
+        $this->dispatch("update-cell-r-{$oldRoomId}-t-{$oldTimeslotId}");
         $this->dispatch("check-programme-status");
     }
 
     /**
      * Renders the component
+     *
      * @return View
      */
     public function render(): View

--- a/app/Livewire/Schedule/GridParentComponent.php
+++ b/app/Livewire/Schedule/GridParentComponent.php
@@ -68,6 +68,7 @@ class GridParentComponent extends Component
         $this->lectureCount = $this->unscheduledPresentations->where('type', 'lecture')->count();
         $this->workshopCount = $this->unscheduledPresentations->where('type', 'workshop')->count();
         $this->dispatch("update-cell-r-{$presentation->room->id}-t-{$presentation->timeslot->id}");
+        $this->dispatch("check-programme-status");
     }
 
     /**

--- a/app/Livewire/Schedule/GridParentComponent.php
+++ b/app/Livewire/Schedule/GridParentComponent.php
@@ -7,6 +7,7 @@ use App\Models\Room;
 use App\Models\Sponsorship;
 use App\Models\Timeslot;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -54,6 +55,8 @@ class GridParentComponent extends Component
     #[On('move-presentation')]
     public function proccessMovingPresentation($data)
     {
+        $this->authorize('edit-schedule');
+
         $presentation = Presentation::find($data['presentation_id']);
         $oldRoom = $presentation->room;
         $oldTimeslot = $presentation->timeslot;

--- a/app/Livewire/Schedule/Presentation.php
+++ b/app/Livewire/Schedule/Presentation.php
@@ -82,7 +82,7 @@ class Presentation extends Component
     #[On("update-presentation-{id}")]
     public function refresh()
     {
-        $this->presentation = $this->presentation->fresh();
+        $this->presentation = $this->presentation->refresh();
         $this->height = $this->calculateHeightInREM();
         $this->marginTop = $this->calculateMarginTopInREM();
     }

--- a/app/Livewire/Schedule/PresentationModal.php
+++ b/app/Livewire/Schedule/PresentationModal.php
@@ -95,6 +95,12 @@ class PresentationModal extends ModalComponent
         $validator->validate();
     }
 
+    /**
+     * Handles removing of participant of presentation if needed and sends an
+     * event to the parent to handle removing of the presentation from the schedule
+     *
+     * @return void
+     */
     public function remove()
     {
         if (Edition::current()->is_final_programme_released) {

--- a/app/Livewire/Schedule/PresentationModal.php
+++ b/app/Livewire/Schedule/PresentationModal.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Schedule;
 
 use App\Actions\Schedule\PresentationAllocationHelper;
 use App\Actions\Schedule\PresentationConflictChecker;
+use App\Models\Edition;
 use App\Models\Room;
 use App\Models\Timeslot;
 use Illuminate\Support\Carbon;
@@ -96,6 +97,13 @@ class PresentationModal extends ModalComponent
 
     public function remove()
     {
+        if (Edition::current()->is_final_programme_released) {
+            $participants = $this->presentation->participants;
+            foreach ($participants as $participant) {
+                $participant->leavePresentation($this->presentation);
+            }
+        }
+
         $this->dispatch('remove-presentation', data: [
             'presentation_id' => $this->presentation->id
         ]);

--- a/app/Livewire/Schedule/PresentationModal.php
+++ b/app/Livewire/Schedule/PresentationModal.php
@@ -48,6 +48,8 @@ class PresentationModal extends ModalComponent
      */
     public function save()
     {
+        $this->authorize('edit-schedule');
+
         $this->validate();
         $this->additionalStartTimeValidation($this->start);
 

--- a/app/Livewire/Schedule/PresentationModal.php
+++ b/app/Livewire/Schedule/PresentationModal.php
@@ -94,11 +94,20 @@ class PresentationModal extends ModalComponent
         $validator->validate();
     }
 
+    public function remove()
+    {
+        $this->dispatch('remove-presentation', data: [
+            'presentation_id' => $this->presentation->id
+        ]);
+
+        $this->closeModal();
+    }
+
     /**
      * Renders the component
      * @return View
      */
-    public function render() : View
+    public function render(): View
     {
         return view('livewire.schedule.presentation-modal');
     }

--- a/app/Livewire/Schedule/PublishProgrammeButton.php
+++ b/app/Livewire/Schedule/PublishProgrammeButton.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Livewire\Schedule;
+
+use App\Models\Presentation;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Masmerise\Toaster\Toaster;
+
+class PublishProgrammeButton extends Component
+{
+    public $isReadyToBePublished;
+    public $oldValue;
+
+    public $buttonClasses = "flex items-center justify-center p-3 text-sm font-semibold rounded-md focus:outline-none
+    focus:ring-2 focus:ring-offset-2 focus:ring-crew-400";
+    public $enabledClasses = "text-white bg-apricot-peach-500 hover:bg-apricot-peach-500";
+    public $disabledClasses = "text-gray-100 bg-gray-600";
+    public $iconClasses = "w-5 h-5 mr-2";
+
+
+    /**
+     * Initializes the component
+     *
+     * @return void
+     */
+    public function mount()
+    {
+        $this->isReadyToBePublished = Presentation::all()->every(function ($presentation) {
+            return $presentation->isScheduled && $presentation->is_approved;
+        });
+
+        $this->oldValue = $this->isReadyToBePublished;
+    }
+
+    /**
+     * Function that rechecks whether the programme is ready for release
+     *
+     * @return void
+     */
+    #[On('check-programme-status')]
+    public function checkIfProgrammeisReadyForRelease()
+    {
+        $this->isReadyToBePublished = Presentation::all()->every(function ($presentation) {
+            return $presentation->isScheduled && $presentation->is_approved;
+        });
+
+        if ($this->isReadyToBePublished && $this->isReadyToBePublished != $this->oldValue) {
+            Toaster::success('The programme is ready to be
+            published whenever you wish if the state remains the same.');
+        }
+
+        $this->oldValue = $this->isReadyToBePublished;
+    }
+
+    /**
+     * Renders the component
+     *
+     * @return View
+     */
+    public function render(): View
+    {
+        return view('livewire.schedule.publish-programme-button');
+    }
+}

--- a/app/Livewire/Schedule/PublishProgrammeModal.php
+++ b/app/Livewire/Schedule/PublishProgrammeModal.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire\Schedule;
+
+use Illuminate\View\View;
+use Livewire\Component;
+use LivewireUI\Modal\ModalComponent;
+
+class PublishProgrammeModal extends ModalComponent
+{
+    /**
+     * Renders the component
+     *
+     * @return View
+     */
+    public function render() : View
+    {
+        return view('livewire.schedule.publish-programme-modal');
+    }
+}

--- a/app/Models/Edition.php
+++ b/app/Models/Edition.php
@@ -77,7 +77,9 @@ class Edition extends Model
     }
 
     /**
-     * Establishes a relationship between Edition and EditionEvent models (events that are executed during given edition)
+     * Establishes a relationship between Edition and
+     * EditionEvent models (events that are executed during given edition)
+     *
      * @return HasMany
      */
     public function editionEvents(): HasMany

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -36,7 +36,8 @@ class Presentation extends Model
      *
      * @return \Illuminate\Database\Eloquent\HigherOrderBuilderProxy|mixed
      */
-    public static function lectureDuration() {
+    public static function lectureDuration()
+    {
         return Edition::current()->lecture_duration;
     }
 
@@ -45,7 +46,8 @@ class Presentation extends Model
      *
      * @return \Illuminate\Database\Eloquent\HigherOrderBuilderProxy|mixed
      */
-    public static function workshopDuration() {
+    public static function workshopDuration()
+    {
         return Edition::current()->workshop_duration;
     }
 

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -14,7 +14,7 @@ class Presentation extends Model
     use HasFactory;
 
     protected $fillable = ['name', 'max_participants', 'description', 'type', 'difficulty_id', 'file_path',
-        'company_id', 'room_id', 'timeslot_id', 'start'];
+        'company_id', 'room_id', 'timeslot_id', 'start', 'is_approved'];
 
     /**
      * Returns the basic validation rules for the model
@@ -195,5 +195,17 @@ class Presentation extends Model
         return strlen($name) > $maxLength
             ? substr($name, 0, $maxLength)
             . '...' : $name;
+    }
+
+    /**
+     * Checks if the presentation has start, room and timeslot
+     *
+     * @return Attribute
+     */
+    public function isScheduled(): Attribute
+    {
+        return Attribute::make(
+            get: fn() => !is_null($this->start) && !is_null($this->room_id) && !is_null($this->timeslot_id)
+        );
     }
 }

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -32,18 +32,22 @@ class Presentation extends Model
     }
 
     /**
-     * Hard-coding the duration of the lectures
-     * TODO: Once the metatables get added rework this to retrieve data from there
-     * @var int
+     * Returns the duration of the lecture based on the Edition
+     *
+     * @return \Illuminate\Database\Eloquent\HigherOrderBuilderProxy|mixed
      */
-    public static $LECTURE_DURATION = 30;
+    public static function lectureDuration() {
+        return Edition::current()->lecture_duration;
+    }
 
     /**
-     * Hard-coding the duration of the workshops
-     * TODO: Once the metatables get added rework this to retrieve data from there
-     * @var int
+     * Returns the duration of the workshops based on the Edition
+     *
+     * @return \Illuminate\Database\Eloquent\HigherOrderBuilderProxy|mixed
      */
-    public static $WORKSHOP_DURATION = 90;
+    public static function workshopDuration() {
+        return Edition::current()->workshop_duration;
+    }
 
     /**
      * Establishes a relationship between the presentation
@@ -171,8 +175,8 @@ class Presentation extends Model
     {
         return Attribute::make(
             get: fn() => $this->type == 'workshop'
-                ? Presentation::$WORKSHOP_DURATION
-                : Presentation::$LECTURE_DURATION
+                ? Presentation::workshopDuration()
+                : Presentation::lectureDuration()
         );
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\Company;
+use App\Models\User;
 use App\Policies\CompanyPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
@@ -23,5 +24,12 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Gate::policy(Company::class, CompanyPolicy::class);
+
+        Gate::define('view-schedule', function (User $user) {
+            return $user->hasPermissionTo('view schedule');
+        });
+        Gate::define('edit-schedule', function (User $user) {
+            return $user->hasPermissionTo('update schedule');
+        });
     }
 }

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -25,10 +25,10 @@ class CompanyFactory extends Factory
             'description' => $this->faker->paragraph(),
             'phone_number' => $this->faker->phoneNumber,
             'postcode' => '1234 AB',
-            'is_approved' => false,
+            'is_approved' => true,
             'street' => $this->faker->streetAddress,
             'house_number' => $this->faker->numberBetween(0, 10),
-            'city' => $this->faker->city
+            'city' => $this->faker->city,
         ];
     }
 
@@ -42,7 +42,8 @@ class CompanyFactory extends Factory
 
         return $this->state(function (array $attributes) use ($sponsorship) {
             return [
-                'sponsorship_id' => $sponsorship->id
+                'sponsorship_id' => $sponsorship->id,
+                'is_sponsorship_approved' => true
             ];
         });
     }

--- a/database/factories/PresentationFactory.php
+++ b/database/factories/PresentationFactory.php
@@ -59,5 +59,4 @@ class PresentationFactory extends Factory
         'Agile Development: Running in Circles Productively',
         'The Joy of Legacy Code: Archaeology for Programmers'
     ];
-
 }

--- a/database/factories/PresentationFactory.php
+++ b/database/factories/PresentationFactory.php
@@ -18,11 +18,46 @@ class PresentationFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->name,
+            'name' => $this->faker->randomElement($this->presentationTopics),
             'description' => $this->faker->paragraph,
+            'is_approved' => $this->faker->boolean,
             'max_participants' => $this->faker->numberBetween(1, 200),
             'type' => $this->faker->boolean ? 'workshop' : 'lecture',
             'difficulty_id' => $this->faker->numberBetween(1, 3)
         ];
     }
+
+    public $presentationTopics = [
+        'Debugging: The Art of Turning Coffee into Code',
+        'When Code Goes Rogue: Hilarious Debugging Stories',
+        'The Internet of (Silly) Things',
+        'Cloud Computing: No, It’s Not About the Weather',
+        'AI: Artificial Insanity?',
+        'How to Train Your Robot (Not to Steal Your Job)',
+        'The Secret Life of Bugs: A Developer\'s Worst Nightmare',
+        'WiFi Woes: Why Does My Internet Hate Me?',
+        'Hacking 101: How to Make Friends and Annoy People',
+        'The Evolution of Memes: From Dial-Up to Fiber Optic',
+        'Data Breaches: The New Horror Stories',
+        'From Floppy Disks to USB: The Quest for More Space',
+        'The Great Debate: Tabs vs Spaces',
+        'Virtual Reality: Escaping Meetings Since 2020',
+        'Blockchain: The Magic Behind Cryptocurrency Unicorns',
+        'Cybersecurity: Because Clicking That Link Was a Bad Idea',
+        'The Rise of the Machines: Are We in a Sci-Fi Movie?',
+        'Passwords: Keep Calm and Don’t Use ‘123456’',
+        'Software Updates: The Good, the Bad, and the Ugly',
+        'The Browser Wars: Chrome vs Firefox vs The World',
+        'Code Reviews: When Your Code is Judged by Humans',
+        'Server Downtime: The Apocalypse of the Digital Age',
+        'The AI Uprising: Will Siri and Alexa Take Over?',
+        'When Tech Support Becomes Tech Sport',
+        'The Dark Web: Not as Fun as It Sounds',
+        'Backup Plans: Because Murphy’s Law Applies to IT',
+        'The Cloud: Where Data Goes to Party',
+        'Internet Explorer: A Moment of Silence',
+        'Agile Development: Running in Circles Productively',
+        'The Joy of Legacy Code: Archaeology for Programmers'
+    ];
+
 }

--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -17,7 +17,6 @@ class RoomFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->name,
             'max_participants' => $this->faker->numberBetween(0, 200)
         ];
     }

--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -18,7 +18,13 @@ class CompanySeeder extends Seeder
      */
     public function run(): void
     {
-        $companies = Company::factory(5)
+        $companies = Company::factory(2)->create();
+        foreach ($companies as $company) {
+            $company->is_approved = false;
+            $company->save();
+        }
+
+        $companies = Company::factory(2)
             ->has(Booth::factory(1))
             ->has(User::factory(1)->afterCreating(function ($user) {
                 $role = Role::findByName('company representative');
@@ -44,14 +50,14 @@ class CompanySeeder extends Seeder
             $user->joinPresentation($presentation, 'speaker');
         }
 
-        $companies = Company::factory(3)->hasSponsorship('silver')
+        $companies = Company::factory(1)->hasSponsorship('silver')
             ->has(User::factory(1)->afterCreating(function ($user) {
                 $role = Role::findByName('company representative');
                 $user->assignRole($role);
             }))->create();
         $this->setPresentation($companies);
 
-        $companies = Company::factory(5)->hasSponsorship('bronze')
+        $companies = Company::factory(2)->hasSponsorship('bronze')
             ->has(User::factory(1)->afterCreating(function ($user) {
                 $role = Role::findByName('company representative');
                 $user->assignRole($role);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,8 +25,23 @@ class DatabaseSeeder extends Seeder
         Artisan::call('admin:upsert-master-data');
         Artisan::call('admin:sync-permissions');
 
-        Room::factory()->count(20)->create();
+        foreach ($this->roomNames as $roomName) {
+            Room::factory()->create([
+                'name' => $roomName
+            ]);
+        }
 
         $this->call([CompanySeeder::class, UserSeeder::class, EditionSeeder::class]);
     }
+
+    public $roomNames = [
+        'GW027',
+        'GW011',
+        'GW012',
+        'GW013',
+        'GW014',
+        'GW317',
+        'GW319',
+        'RC213'
+    ];
 }

--- a/resources/views/crew/schedule/index.blade.php
+++ b/resources/views/crew/schedule/index.blade.php
@@ -12,26 +12,26 @@
             <div class="flex gap-3">
                 <button class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
                         onclick="Livewire.dispatch('openModal', { component: 'schedule.edit-default-presentation-modal', arguments: { type: 'opening' }})">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-6 h-6 mr-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
                     </svg>
                     <span>Edit Opening</span>
                 </button>
                 <button class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
                         onclick="Livewire.dispatch('openModal', { component: 'schedule.edit-default-presentation-modal', arguments: { type: 'closing' }})">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-6 h-6 mr-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
                     </svg>
                     <span>Edit Closing</span>
                 </button>
                 <button class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
                         onclick="Livewire.dispatch('openModal', { component: 'schedule.confirm-reset-schedule-modal' })">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-6 h-6 mr-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"></path>
                     </svg>
                     <span>Reset</span>
                 </button>
-
+                <livewire:schedule.publish-programme-button/>
             </div>
             @endif
         </div>

--- a/resources/views/crew/schedule/index.blade.php
+++ b/resources/views/crew/schedule/index.blade.php
@@ -9,35 +9,57 @@
                 {{ __('Schedule management') }}
             </h1>
             @if(DefaultPresentation::opening() && DefaultPresentation::closing())
-            <div class="flex gap-3">
-                <button class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
+                <div class="flex gap-3">
+                    <button
+                        class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
                         onclick="Livewire.dispatch('openModal', { component: 'schedule.edit-default-presentation-modal', arguments: { type: 'opening' }})">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
-                    </svg>
-                    <span>Edit Opening</span>
-                </button>
-                <button class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                             stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
+                        </svg>
+                        <span>Edit Opening</span>
+                    </button>
+                    <button
+                        class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
                         onclick="Livewire.dispatch('openModal', { component: 'schedule.edit-default-presentation-modal', arguments: { type: 'closing' }})">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
-                    </svg>
-                    <span>Edit Closing</span>
-                </button>
-                <button class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                             stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
+                        </svg>
+                        <span>Edit Closing</span>
+                    </button>
+                    <button
+                        class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"
                         onclick="Livewire.dispatch('openModal', { component: 'schedule.confirm-reset-schedule-modal' })">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"></path>
-                    </svg>
-                    <span>Reset</span>
-                </button>
-                <livewire:schedule.publish-programme-button/>
-            </div>
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                             stroke="currentColor" aria-hidden="true" class="w-5 h-5 mr-2">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"></path>
+                        </svg>
+                        <span>Reset</span>
+                    </button>
+                    <livewire:schedule.publish-programme-button/>
+                </div>
             @endif
         </div>
 
-
-    @if(is_null(DefaultPresentation::opening()) || is_null(DefaultPresentation::closing()))
+        @if($noActiveEdition)
+            <div class="flex items-center justify-center h-screen">
+                <div class="text-center w-3/4 h-3/4">
+                    <h2 class="text-3xl">Heads Up!</h2>
+                    <p class='py-5'>In order to access the scheduling, you must first set an active edition.</p>
+                    <div class="grid grid-cols-1 w-full">
+                        <div class="w-full">
+                            <a href="{{route('moderator.editions.index')}}" class="bg-crew-300 py-2 px-3 border border-crew-400 hover:bg-crew-400 rounded">
+                                Go to Editions management
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @elseif(is_null(DefaultPresentation::opening()) || is_null(DefaultPresentation::closing()))
             <x-schedule.set-default-presentations/>
         @else
             <livewire:schedule.grid-parent-component/>

--- a/resources/views/crew/schedule/index.blade.php
+++ b/resources/views/crew/schedule/index.blade.php
@@ -1,6 +1,7 @@
 @php
     use Carbon\Carbon;
     use App\Models\DefaultPresentation;
+    use App\Models\Edition;
 @endphp
 <x-hub-layout>
     <div class="py-8 px-8 mx-auto max-w-7xl">
@@ -8,7 +9,7 @@
             <h1 class="font-semibold text-3xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ __('Schedule management') }}
             </h1>
-            @if(DefaultPresentation::opening() && DefaultPresentation::closing())
+            @if(DefaultPresentation::opening() && DefaultPresentation::closing() && Edition::current() && !Edition::current()->is_final_programme_released)
                 <div class="flex gap-3">
                     <button
                         class="flex items-center justify-center p-3 text-sm font-semibold text-white bg-apricot-peach-400 rounded-md hover:bg-apricot-peach-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-crew-400"

--- a/resources/views/livewire/auth-navigation-menu.blade.php
+++ b/resources/views/livewire/auth-navigation-menu.blade.php
@@ -35,7 +35,7 @@
                 </div>
                 @if(Edition::current() && Edition::current()->is_final_programme_released)
                     <div class="hidden space-x-8 sm:-my-px sm:ml-5 sm:flex">
-                        <x-nav-link href="{{ route('programme') }}" :active="request()->routeIs('programme')">
+                        <x-nav-link {{--href="{{ route('programme') }}" :active="request()->routeIs('programme')"--}}>
                             {{ __('Programme') }}
                         </x-nav-link>
                     </div>
@@ -139,7 +139,7 @@
                 {{ __('Companies') }}
             </x-responsive-nav-link>
             @if(Edition::current() && Edition::current()->is_final_programme_released)
-                <x-responsive-nav-link href="{{ route('programme') }}" :active="request()->routeIs('programme')">
+                <x-responsive-nav-link {{--href="{{ route('programme') }}" :active="request()->routeIs('programme')"--}}>
                     {{ __('Programme') }}
                 </x-responsive-nav-link>
             @endif

--- a/resources/views/livewire/guest-navigation-menu.blade.php
+++ b/resources/views/livewire/guest-navigation-menu.blade.php
@@ -36,7 +36,7 @@
 
                 @if(Edition::current() && Edition::current()->is_final_programme_released)
                     <div class="hidden space-x-8 sm:-my-px sm:ml-5 sm:flex">
-                        <x-nav-link href="{{ route('programme') }}" :active="request()->routeIs('programme')">
+                        <x-nav-link {{--href="{{ route('programme') }}" :active="request()->routeIs('programme')"--}}>
                             {{ __('Programme') }}
                         </x-nav-link>
                     </div>
@@ -115,7 +115,7 @@
             </x-responsive-nav-link>
 
             @if(Edition::current() && Edition::current()->is_final_programme_released)
-                <x-responsive-nav-link href="{{ route('programme') }}" :active="request()->routeIs('programme')">
+                <x-responsive-nav-link {{--href="{{ route('programme') }}" :active="request()->routeIs('programme')"--}}>
                     {{ __('Programme') }}
                 </x-responsive-nav-link>
             @endif

--- a/resources/views/livewire/presentation/edit-presentation-modal.blade.php
+++ b/resources/views/livewire/presentation/edit-presentation-modal.blade.php
@@ -33,8 +33,8 @@
                 <dd class="sm:col-span-2">
                     <select wire:model="form.type"
                             class="mt-1 w-full bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-900 dark:border-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-indigo-500 dark:focus:border-indigo-500">
-                        <option value="lecture">Lecture (30 minutes)</option>
-                        <option value="workshop">Workshop (90 minutes)</option>
+                        <option value="lecture">Lecture ({{\App\Models\Presentation::lectureDuration()}} minutes)</option>
+                        <option value="workshop">Workshop ({{\App\Models\Presentation::workshopDuration()}} minutes)</option>
                     </select>
                     @error('form.type') <span class="error text-red-500">{{ $message }}</span> @enderror
                 </dd>

--- a/resources/views/livewire/schedule/cell.blade.php
+++ b/resources/views/livewire/schedule/cell.blade.php
@@ -1,7 +1,9 @@
 <div class="flex-none h-full w-full" x-data="draggable()"
-     @drop.prevent="drop"
-     @dragover.prevent="allowDrop"
-     @draggable
+     @if(\App\Models\Edition::current() && !\App\Models\Edition::current()->is_final_programme_released)
+         @drop.prevent="drop"
+         @dragover.prevent="allowDrop"
+         @draggable
+     @endif
      data-room="{{ $room->id }}"
      data-timeslot="{{$timeslot->id}}"
      style="height: {{ $height }}rem">

--- a/resources/views/livewire/schedule/grid-parent-component.blade.php
+++ b/resources/views/livewire/schedule/grid-parent-component.blade.php
@@ -3,65 +3,79 @@
     <div class="flex-none w-58 mr-4 pt-2">
         <div class="mb-4 p-2">
             <h2 class="font-bold text-xl mb-2 text-center">Unscheduled</h2>
-            <div class="mb-4 bg-white p-3">
+            <div class="mb-4 bg-white dark:bg-gray-800 p-3">
                 <h3 class="font-bold text-lg mb-2 text-center text-crew-300 p-1 rounded">Lectures</h3>
                 <ul class="space-y-1">
-                    @foreach ($unscheduledPresentations as $presentation)
-                        @if ($presentation->type === 'lecture')
-                            <li wire:key="task-{{ $presentation->id }}"
-                                x-data="draggable()"
-                                draggable="true"
-                                @dragstart="dragStart"
-                                data-id="{{ $presentation->id }}"
-                                data-room="0"
-                                class="p-2 h-20 bg-crew-100 rounded shadow hover:bg-crew-200 cursor-pointer dark:bg-gray-700 dark:hover:bg-gray-600">
-                                <div class="grid grid-cols-1">
+                    @if($lectureCount > 0)
+                        @foreach ($unscheduledPresentations as $presentation)
+                            @if ($presentation->type === 'lecture')
+                                <li wire:key="task-{{ $presentation->id }}"
+                                    x-data="draggable()"
+                                    draggable="true"
+                                    @dragstart="dragStart"
+                                    data-id="{{ $presentation->id }}"
+                                    data-room="0"
+                                    class="p-2 h-20 bg-crew-100 rounded shadow hover:bg-crew-200 cursor-pointer dark:bg-crew-400/50 dark:hover:bg-crew-400/70">
+                                    <div class="grid grid-cols-1">
                                     <span class="col-span-1">
                                         {{ $presentation->displayName(20) }}
                                     </span>
-                                    <span class="text-xs col-span-1">
+                                        <span class="text-xs col-span-1">
                                           {{ strlen($presentation->speakersName) > 29 ? substr($presentation->speakersName, 0, 29) . '...' : $presentation->speakersName }}
                                     </span>
-                                    @if($presentation->company)
-                                        <span class="text-xs col-span-1">
+                                        @if($presentation->company)
+                                            <span class="text-xs col-span-1">
                                           {{ strlen($presentation->company->name) > 29 ? substr($presentation->company->name, 0, 29) . '...' : $presentation->company->name }}
                                         </span>
-                                    @endif
-                                </div>
-                            </li>
-                        @endif
-                    @endforeach
+                                        @endif
+                                    </div>
+                                </li>
+                            @endif
+                        @endforeach
+                    @else
+                        <div
+                            class="p-2 text-center text-sm rounded dark:text-gray-100">
+                            All lectures are scheduled.
+                        </div>
+                    @endif
                 </ul>
             </div>
 
-            <div class="mb-4 bg-white p-3">
+            <div class="mb-4 bg-white dark:bg-gray-800 p-3">
                 <h3 class="font-bold text-lg mb-2 text-center text-apricot-peach-400 p-1 rounded">Workshops</h3>
                 <ul class="space-y-1 ">
-                    @foreach ($unscheduledPresentations as $presentation)
-                        @if ($presentation->type === 'workshop')
-                            <li wire:key="task-{{ $presentation->id }}"
-                                x-data="draggable()"
-                                draggable="true"
-                                @dragstart="dragStart"
-                                data-id="{{ $presentation->id }}"
-                                data-room="0"
-                                class="p-2 h-20 bg-apricot-peach-200 rounded shadow hover:bg-apricot-peach-300 cursor-pointer dark:bg-gray-700 dark:hover:bg-gray-600">
-                                <div class="grid grid-cols-1">
+                    @if($workshopCount > 0)
+                        @foreach ($unscheduledPresentations as $presentation)
+                            @if ($presentation->type === 'workshop')
+                                <li wire:key="task-{{ $presentation->id }}"
+                                    x-data="draggable()"
+                                    draggable="true"
+                                    @dragstart="dragStart"
+                                    data-id="{{ $presentation->id }}"
+                                    data-room="0"
+                                    class="p-2 h-20 bg-apricot-peach-200 rounded shadow hover:bg-apricot-peach-300 cursor-pointer dark:bg-apricot-peach-700/50 dark:hover:bg-apricot-peach-600/75">
+                                    <div class="grid grid-cols-1">
                                     <span class="col-span-1">
                                         {{ $presentation->displayName(20) }}
                                     </span>
-                                    <span class="text-xs col-span-1">
+                                        <span class="text-xs col-span-1">
                                           {{ strlen($presentation->speakersName) > 29 ? substr($presentation->speakersName, 0, 29) . '...' : $presentation->speakersName }}
                                     </span>
-                                    @if($presentation->company)
-                                        <span class="text-xs col-span-1">
+                                        @if($presentation->company)
+                                            <span class="text-xs col-span-1">
                                           {{ strlen($presentation->company->name) > 29 ? substr($presentation->company->name, 0, 29) . '...' : $presentation->company->name }}
                                         </span>
-                                    @endif
-                                </div>
-                            </li>
-                        @endif
-                    @endforeach
+                                        @endif
+                                    </div>
+                                </li>
+                            @endif
+                        @endforeach
+                    @else
+                        <div
+                            class="p-2 text-center text-sm rounded dark:text-gray-100">
+                            All workshops are scheduled.
+                        </div>
+                    @endif
                 </ul>
             </div>
         </div>

--- a/resources/views/livewire/schedule/presentation-modal.blade.php
+++ b/resources/views/livewire/schedule/presentation-modal.blade.php
@@ -1,6 +1,9 @@
-<x-livewire-modal form-action="save">
+<x-livewire-modal>
     <x-slot name="title" class="dark:bg-gray-900 border-gray-800">
-        Edit {{$presentation->name}} scheduling details
+        <div>Edit {{$presentation->name}} scheduling details</div>
+        <div class="text-sm pt-1 text-gray-600 dark:text-gray-200">Searching for other details for the presentation?
+            <a href="{{route('moderator.presentations.show', $presentation)}}" class="underline text-crew-600 bg:text-crew-700">Click here!</a>
+        </div>
     </x-slot>
 
     <x-slot name="content" class="w-full dark:bg-gray-800">
@@ -38,7 +41,11 @@
         <x-secondary-button type="button" wire:click="$dispatch('closeModal')" class="mr-3">
             {{ __('Cancel') }}
         </x-secondary-button>
-        <button type="submit"
+        <button wire:click="remove"
+                class="mr-3 inline-flex items-center px-4 py-2 bg-red-800 dark:bg-red-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-700 dark:hover:bg-red-800 focus:bg-red-700 dark:focus:bg-red-800 active:bg-red-900 dark:active:bg-red-300 focus:outline-none focus:ring-2 focus:ring-crew-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+            Remove
+        </button>
+        <button wire:click="save"
                 class="inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-crew-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
             Save
         </button>

--- a/resources/views/livewire/schedule/presentation-modal.blade.php
+++ b/resources/views/livewire/schedule/presentation-modal.blade.php
@@ -2,7 +2,8 @@
     <x-slot name="title" class="dark:bg-gray-900 border-gray-800">
         <div>Edit {{$presentation->name}} scheduling details</div>
         <div class="text-sm pt-1 text-gray-600 dark:text-gray-200">Searching for other details for the presentation?
-            <a href="{{route('moderator.presentations.show', $presentation)}}" class="underline text-crew-600 bg:text-crew-700">Click here!</a>
+            <a href="{{route('moderator.presentations.show', $presentation)}}"
+               class="underline text-crew-600 bg:text-crew-700">Click here!</a>
         </div>
     </x-slot>
 
@@ -11,29 +12,36 @@
             {{$errorMessage}}
         </div>
         <div class="px-4 py-4 sm:px-0">
-            <dl class="sm:grid sm:grid-cols-3 sm:gap-6">
-                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Presentation room</dt>
-                <dd class="sm:col-span-2">
-                    <select name="type"
-                            wire:model="room_id"
-                            class="mt-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-crew-500 focus:border-crew-500 block w-full p-2.5 dark:bg-gray-900 dark:border-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-crew-500 dark:focus:border-crew-500">
-                        @foreach($rooms as $room)
-                            <option
-                                value="{{$room->id}}"> {{$room->name}}
-                            </option>
-                        @endforeach
-                    </select>
-                    @error('room_id') <span class="error text-red-500">{{ $message }}</span> @enderror
-                </dd>
-                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Presentation starting time</dt>
-                <dd class="sm:col-span-2">
-                    <!-- TODO: Once metatable exist fix the min max -->
-                    <input
-                        class="w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-crew-500 dark:focus:border-crew-600 focus:ring-crew-500 dark:focus:ring-crew-600 rounded-md shadow-sm mt-1 block"
-                        type="time" min="8:00" max="18:00" wire:model="start" value={{$presentation->start}}>
-                    @error('start') <span class="error text-red-500">{{ $message }}</span> @enderror
-                </dd>
-            </dl>
+            @if(!\App\Models\Edition::current()->is_final_programme_released)
+                <dl class="sm:grid sm:grid-cols-3 sm:gap-6">
+                    <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Presentation room</dt>
+                    <dd class="sm:col-span-2">
+                        <select name="type"
+                                wire:model="room_id"
+                                class="mt-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-crew-500 focus:border-crew-500 block w-full p-2.5 dark:bg-gray-900 dark:border-gray-700 dark:placeholder-gray-400 dark:text-white dark:focus:ring-crew-500 dark:focus:border-crew-500">
+                            @foreach($rooms as $room)
+                                <option
+                                    value="{{$room->id}}"> {{$room->name}}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('room_id') <span class="error text-red-500">{{ $message }}</span> @enderror
+                    </dd>
+                    <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Presentation starting time
+                    </dt>
+                    <dd class="sm:col-span-2">
+                        <!-- TODO: Once metatable exist fix the min max -->
+                        <input
+                            class="w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-crew-500 dark:focus:border-crew-600 focus:ring-crew-500 dark:focus:ring-crew-600 rounded-md shadow-sm mt-1 block"
+                            type="time" min="8:00" max="18:00" wire:model="start" value={{$presentation->start}}>
+                        @error('start') <span class="error text-red-500">{{ $message }}</span> @enderror
+                    </dd>
+                </dl>
+            @else
+                <div class="text-red-500">
+                    Warning: If you remove the presentation while the programme is released, it means that it cannot be added anymore and all of the participants will be automatically deregistered from it.
+                </div>
+            @endif
         </div>
     </x-slot>
 
@@ -45,9 +53,11 @@
                 class="mr-3 inline-flex items-center px-4 py-2 bg-red-800 dark:bg-red-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-700 dark:hover:bg-red-800 focus:bg-red-700 dark:focus:bg-red-800 active:bg-red-900 dark:active:bg-red-300 focus:outline-none focus:ring-2 focus:ring-crew-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
             Remove
         </button>
-        <button wire:click="save"
-                class="inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-crew-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
-            Save
-        </button>
+        @if(!\App\Models\Edition::current()->is_final_programme_released)
+            <button wire:click="save"
+                    class="inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-crew-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+                Save
+            </button>
+        @endif
     </x-slot>
 </x-livewire-modal>

--- a/resources/views/livewire/schedule/publish-programme-button.blade.php
+++ b/resources/views/livewire/schedule/publish-programme-button.blade.php
@@ -1,0 +1,14 @@
+<button class="{{ $buttonClasses }} {{ $isReadyToBePublished ? $enabledClasses : $disabledClasses }}"
+        onclick="Livewire.dispatch('openModal', { component: 'schedule.publish-programme-modal' })"
+        @if(!$isReadyToBePublished) disabled @endif>
+    @if($isReadyToBePublished)
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="{{ $iconClasses }}">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"></path>
+        </svg>
+    @else
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="{{ $iconClasses }}">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"></path>
+        </svg>
+    @endif
+    <span>Publish programme</span>
+</button>

--- a/resources/views/livewire/schedule/publish-programme-button.blade.php
+++ b/resources/views/livewire/schedule/publish-programme-button.blade.php
@@ -2,12 +2,16 @@
         onclick="Livewire.dispatch('openModal', { component: 'schedule.publish-programme-modal' })"
         @if(!$isReadyToBePublished) disabled @endif>
     @if($isReadyToBePublished)
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="{{ $iconClasses }}">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"></path>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+             aria-hidden="true" class="{{ $iconClasses }}">
+            <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"></path>
         </svg>
     @else
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="{{ $iconClasses }}">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"></path>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+             aria-hidden="true" class="{{ $iconClasses }}">
+            <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"></path>
         </svg>
     @endif
     <span>Publish programme</span>

--- a/resources/views/livewire/schedule/publish-programme-modal.blade.php
+++ b/resources/views/livewire/schedule/publish-programme-modal.blade.php
@@ -1,14 +1,11 @@
 <x-livewire-modal>
     <x-slot name="title" class="dark:bg-gray-900 border-gray-800">
-        Reset the schedule
+        Publish the programme
     </x-slot>
 
     <x-slot name="content" class="w-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200">
         <h3 class="font-bold text-red-600">{{ __('WARNING: this action cannot be undone') }}</h3>
-        <p>Are you sure you want to reset the schedule? There are two types of reset
-        - full reset or scheduled reset.<br>The full reset removes all scheduled presentations including
-        the opening and closing presentation that you created in the beginning.<br>The scheduled presentation reset leaves
-        the opening and closing but removes all of the scheduled presentations after them.</p>
+        <p>Are you sure you want to publish the programme? After the programme is published, you will not be able to move the presentations around anymore. The rooms and presentations will stay as definitive. The only possible change in the programme that can be done is the removing of scheduled presentations. </p>
     </x-slot>
 
     <x-slot name="buttons" class="dark:bg-gray-900 border-gray-800">
@@ -19,13 +16,7 @@
         <form method="POST" action="{{route('moderator.schedule.reset', 'full')}}" class="pl-2">
             @csrf
             <x-danger-button class="ml-3" type="submit">
-                {{ __('Full Reset') }}
-            </x-danger-button>
-        </form>
-        <form method="POST" action="{{route('moderator.schedule.reset', 'scheduled')}}" class="pl-2">
-            @csrf
-            <x-danger-button class="ml-3" type="submit">
-                {{ __('Scheduled Reset') }}
+                {{ __('Publish programme') }}
             </x-danger-button>
         </form>
     </x-slot>

--- a/resources/views/livewire/schedule/publish-programme-modal.blade.php
+++ b/resources/views/livewire/schedule/publish-programme-modal.blade.php
@@ -13,7 +13,7 @@
             {{ __('Cancel') }}
         </x-secondary-button>
 
-        <form method="POST" action="{{route('moderator.schedule.reset', 'full')}}" class="pl-2">
+        <form method="POST" action="{{route('moderator.schedule.publish')}}" class="pl-2">
             @csrf
             <x-danger-button class="ml-3" type="submit">
                 {{ __('Publish programme') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -172,7 +172,7 @@ Route::middleware([
         ->name('schedule.index');
     Route::post('/schedule/reset/{type}', [ScheduleController::class, 'reset'])
         ->name('schedule.reset');
-    Route::post('/schedule/publish}', [ScheduleController::class, 'publishFinalProgramme'])
+    Route::post('/schedule/publish', [ScheduleController::class, 'publishFinalProgramme'])
         ->name('schedule.publish');
 
     /*    Route::get('/schedule/timeslots', [TimeslotController::class, 'create'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -172,6 +172,8 @@ Route::middleware([
         ->name('schedule.index');
     Route::post('/schedule/reset/{type}', [ScheduleController::class, 'reset'])
         ->name('schedule.reset');
+    Route::post('/schedule/publish}', [ScheduleController::class, 'publishFinalProgramme'])
+        ->name('schedule.publish');
 
     /*    Route::get('/schedule/timeslots', [TimeslotController::class, 'create'])
             ->name('schedule.timeslots.create');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ export default {
         'bg-crew-300',
         'bg-crew-500',
         'bg-apricot-peach-500',
+        'bg-gray-600',
         'bg-apricot-peach-300'
     ],
     theme: {

--- a/tests/Feature/CompanyControllerTest.php
+++ b/tests/Feature/CompanyControllerTest.php
@@ -226,6 +226,8 @@ class CompanyControllerTest extends TestCase
     {
         $user = User::factory()->create()->assignRole('participant');
         $company = Company::factory()->create();
+        $company->is_approved = false;
+        $company->save();
 
         $response = $this->actingAs($user)->post(route('moderator.companies.approve', $company), [
             'approved' => true

--- a/tests/Feature/PresentationControllerTest.php
+++ b/tests/Feature/PresentationControllerTest.php
@@ -186,6 +186,8 @@ class PresentationControllerTest extends TestCase
     {
         $user = User::factory()->create()->assignRole('participant');
         $presentation = Presentation::factory()->create();
+        $presentation->is_approved = false;
+        $presentation->save();
 
         $response = $this->actingAs($user)
             ->post(route('moderator.presentations.approve', $presentation), ['approved' => true]);

--- a/tests/Feature/RoomControllerTest.php
+++ b/tests/Feature/RoomControllerTest.php
@@ -109,7 +109,9 @@ class RoomControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $user->assignRole('event organizer');
-        $room = Room::factory()->create();
+        $room = Room::factory()->create([
+            'name' => 'Random name'
+        ]);
         $response = $this->actingAs($user)->get(route('moderator.rooms.show', $room));
 
         $response->assertStatus(200);
@@ -122,7 +124,9 @@ class RoomControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $user->assignRole('participant');
-        $room = Room::factory()->create();
+        $room = Room::factory()->create([
+            'name' => 'Random name'
+        ]);
         $response = $this->actingAs($user)->get(route('moderator.rooms.show', $room));
 
         $response->assertStatus(403);
@@ -132,7 +136,9 @@ class RoomControllerTest extends TestCase
     public function destroy_deletes_and_redirects_to_crew()
     {
         $user = User::factory()->create();
-        $room = Room::factory()->create();
+        $room = Room::factory()->create([
+            'name' => 'Random name'
+        ]);
         $roomCount = Room::all()->count();
         $user->assignRole('event organizer');
 
@@ -147,7 +153,9 @@ class RoomControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $user->assignRole('participant');
-        $room = Room::factory()->create();
+        $room = Room::factory()->create([
+            'name' => 'Random name'
+        ]);
         $roomCount = Room::all()->count();
 
         $response = $this->actingAs($user)->delete(route('moderator.rooms.destroy', $room));


### PR DESCRIPTION
# Description

This branch introduces modification on the scheduling tool in regards to the releasing of the programme. It also introduces some fixes on the seeders so that they are more similar to the expected dataflow. This PR is half of the releasing schedule PR's, the other half is done by @IGORnvk. The two PR's compliment each other to build the whole release programme system.

closes #(issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## What needs to be tested

Prerequisite: The user must be logged in as the event organizer
- [x] The schedule works as expected from last time (a.k.a no features were accidentally broken)
- [x] A presentation can be removed once it was put in the schedule
- [x] The programme cannot be published unless: all approved presentations are scheduled and all presentations are approved/disapproved
- [x] The scheduling page shows only presentations that have been approved
- [x] Once the programme is released the schedule cannot be editted with the exception of removing presentation (cancelling the presentation)
- [x] If a presentation is scheduled, programme released, when it's cancelled, all of the participants enrolled are automatically deregistered from that presentation

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

