### PR TITLE
Rework - Display sponsors on welcome page

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,160 @@
+<?php
+
+return [
+
+    /*
+    |---------------------------------------------------------------------------
+    | Class Namespace
+    |---------------------------------------------------------------------------
+    |
+    | This value sets the root class namespace for Livewire component classes in
+    | your application. This value will change where component auto-discovery
+    | finds components. It's also referenced by the file creation commands.
+    |
+    */
+
+    'class_namespace' => 'App\\Livewire',
+
+    /*
+    |---------------------------------------------------------------------------
+    | View Path
+    |---------------------------------------------------------------------------
+    |
+    | This value is used to specify where Livewire component Blade templates are
+    | stored when running file creation commands like `artisan make:livewire`.
+    | It is also used if you choose to omit a component's render() method.
+    |
+    */
+
+    'view_path' => resource_path('views/livewire'),
+
+    /*
+    |---------------------------------------------------------------------------
+    | Layout
+    |---------------------------------------------------------------------------
+    | The view that will be used as the layout when rendering a single component
+    | as an entire page via `Route::get('/post/create', CreatePost::class);`.
+    | In this case, the view returned by CreatePost will render into $slot.
+    |
+    */
+
+    'layout' => 'components.layouts.app',
+
+    /*
+    |---------------------------------------------------------------------------
+    | Lazy Loading Placeholder
+    |---------------------------------------------------------------------------
+    | Livewire allows you to lazy load components that would otherwise slow down
+    | the initial page load. Every component can have a custom placeholder or
+    | you can define the default placeholder view for all components below.
+    |
+    */
+
+    'lazy_placeholder' => null,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Temporary File Uploads
+    |---------------------------------------------------------------------------
+    |
+    | Livewire handles file uploads by storing uploads in a temporary directory
+    | before the file is stored permanently. All file uploads are directed to
+    | a global endpoint for temporary storage. You may configure this below:
+    |
+    */
+
+    'temporary_file_upload' => [
+        'disk' => null,        // Example: 'local', 's3'              | Default: 'default'
+        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  | Default: ['required', 'file', 'max:12288'] (12MB)
+        'directory' => null,   // Example: 'tmp'                      | Default: 'livewire-tmp'
+        'middleware' => null,  // Example: 'throttle:5,1'             | Default: 'throttle:60,1'
+        'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs...
+            'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',
+            'mov', 'avi', 'wmv', 'mp3', 'm4a',
+            'jpg', 'jpeg', 'mpga', 'webp', 'wma', 'image/png', 'image/jpg', 'image/jpeg'
+        ],
+        'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
+        'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | Render On Redirect
+    |---------------------------------------------------------------------------
+    |
+    | This value determines if Livewire will run a component's `render()` method
+    | after a redirect has been triggered using something like `redirect(...)`
+    | Setting this to true will render the view once more before redirecting
+    |
+    */
+
+    'render_on_redirect' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Eloquent Model Binding
+    |---------------------------------------------------------------------------
+    |
+    | Previous versions of Livewire supported binding directly to eloquent model
+    | properties using wire:model by default. However, this behavior has been
+    | deemed too "magical" and has therefore been put under a feature flag.
+    |
+    */
+
+    'legacy_model_binding' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Auto-inject Frontend Assets
+    |---------------------------------------------------------------------------
+    |
+    | By default, Livewire automatically injects its JavaScript and CSS into the
+    | <head> and <body> of pages containing Livewire components. By disabling
+    | this behavior, you need to use @livewireStyles and @livewireScripts.
+    |
+    */
+
+    'inject_assets' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Navigate (SPA mode)
+    |---------------------------------------------------------------------------
+    |
+    | By adding `wire:navigate` to links in your Livewire application, Livewire
+    | will prevent the default link handling and instead request those pages
+    | via AJAX, creating an SPA-like effect. Configure this behavior here.
+    |
+    */
+
+    'navigate' => [
+        'show_progress_bar' => true,
+        'progress_bar_color' => '#2299dd',
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | HTML Morph Markers
+    |---------------------------------------------------------------------------
+    |
+    | Livewire intelligently "morphs" existing HTML into the newly rendered HTML
+    | after each update. To make this process more reliable, Livewire injects
+    | "markers" into the rendered Blade surrounding @if, @class & @foreach.
+    |
+    */
+
+    'inject_morph_markers' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Pagination Theme
+    |---------------------------------------------------------------------------
+    |
+    | When enabling Livewire's pagination feature by using the `WithPagination`
+    | trait, Livewire will use Tailwind templates to render pagination views
+    | on the page. If you want Bootstrap CSS, you can specify: "bootstrap"
+    |
+    */
+
+    'pagination_theme' => 'tailwind',
+];

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -30,6 +30,8 @@ class CompanyFactory extends Factory
             'street' => $this->faker->streetAddress,
             'house_number' => $this->faker->numberBetween(0, 10),
             'city' => $this->faker->city,
+            'logo_path' => 'logos/img.png',
+
         ];
     }
 

--- a/resources/views/livewire/company/manage-logo.blade.php
+++ b/resources/views/livewire/company/manage-logo.blade.php
@@ -26,20 +26,21 @@
                             <x-label for="preview" value="{{ __('Photo preview') }}" class="pt-3 pb-1"/>
                             <img src="{{ $photo->temporaryUrl() }}" class="object-fill w-full h-72">
                         @endif
-                        <div class="mt-1 flex items-center">
-                            <input type="file" id="photo" wire:model="photo"
-                                   class="hidden"
-                                   accept="image/jpeg, image/png, image/gif, image/webp, image/svg+xml, image/bmp, image/tiff">
-                            <label for="photo"
-                                   class="flex items-center justify-center w-1/3 h-10 px-4 mt-2 text-sm font-medium text-white bg-purple-600 rounded-md cursor-pointer hover:bg-purple-600 focus-within:bg-purple-600">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                     stroke="currentColor" class="w-6 h-6 mr-2">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                          d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
-                                </svg>
-                                Upload {{$photo ||  $company->logo_path ? 'new' : ''}} logo
-                            </label>
-                        </div>
+                        @can('update', $company)
+                            <div class="mt-1 flex items-center">
+                                <input type="file" id="photo" wire:model="photo"
+                                       class="hidden">
+                                <label for="photo"
+                                       class="flex items-center justify-center w-1/3 h-10 px-4 mt-2 text-sm font-medium text-white bg-purple-600 rounded-md cursor-pointer hover:bg-purple-600 focus-within:bg-purple-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                         stroke="currentColor" class="w-6 h-6 mr-2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                              d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                                    </svg>
+                                    Upload {{$photo ||  $company->logo_path ? 'new' : ''}} logo
+                                </label>
+                            </div>
+                        @endcan
                         @error('photo') <p class="mt-2 text-sm text-red-600">{{ $message }}</p> @enderror
                     </div>
                 </div>

--- a/resources/views/livewire/company/manage-logo.blade.php
+++ b/resources/views/livewire/company/manage-logo.blade.php
@@ -26,10 +26,10 @@
                             <x-label for="preview" value="{{ __('Photo preview') }}" class="pt-3 pb-1"/>
                             <img src="{{ $photo->temporaryUrl() }}" class="object-fill w-full h-72">
                         @endif
-                        @can('update', $company)
                         <div class="mt-1 flex items-center">
                             <input type="file" id="photo" wire:model="photo"
-                                   class="hidden">
+                                   class="hidden"
+                                   accept="image/jpeg, image/png, image/gif, image/webp, image/svg+xml, image/bmp, image/tiff">
                             <label for="photo"
                                    class="flex items-center justify-center w-1/3 h-10 px-4 mt-2 text-sm font-medium text-white bg-purple-600 rounded-md cursor-pointer hover:bg-purple-600 focus-within:bg-purple-600">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
@@ -40,7 +40,6 @@
                                 Upload {{$photo ||  $company->logo_path ? 'new' : ''}} logo
                             </label>
                         </div>
-                        @endcan
                         @error('photo') <p class="mt-2 text-sm text-red-600">{{ $message }}</p> @enderror
                     </div>
                 </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -238,67 +238,77 @@
 
                 <!-- Third banner-->
                 <div>
-                    <h2 class="flex justify-center mt-8 mb-5 uppercase text-3xl font-montserrat font-bold pl-4">A big thank you to our sponsors</h2>
+                    <h2 class="flex justify-center mt-8 mb-5 uppercase text-3xl font-montserrat font-bold pl-4">A big
+                                                                                                                thank
+                                                                                                                you to
+                                                                                                                our
+                                                                                                                sponsors</h2>
                     <div class="flex flex-col mb-4 text-left pl-4">
                         <div class="text-xl font-montserrat">
                             <div class="py-10">
                                 <h2 class="text-3xl mb-5 font-semibold">Gold sponsor</h2>
                                 <div class="flex flex-wrap">
-                                    @foreach(\App\Models\Sponsorship::find(1)->companies as $company)
-                                        <div class="flex items-center justify-start mr-4 mb-4 w-1/2">
-                                            <a href="{{'https://' . $company->website}}"
-                                               class="bg-gray-50 border h-56 p-5 w-full rounded">
-                                                @if($company->logo_path)
-                                                    <img
-                                                        class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
-                                                        src="{{ url('storage/'. $company->logo_path) }}"
-                                                        alt="Logo of {{$company->name}}">
-                                                @else
-                                                    <h2 class="text-4xl">{{$company->name}}</h2>
-                                                @endif
-                                            </a>
-                                        </div>
-                                    @endforeach
+                                    @if(\App\Models\Sponsorship::find(1))
+                                        @foreach(\App\Models\Sponsorship::find(1)->companies as $company)
+                                            <div class="flex items-center justify-start mr-4 mb-4 w-1/2">
+                                                <a href="{{'https://' . $company->website}}"
+                                                   class="bg-gray-50 border h-56 p-5 w-full rounded">
+                                                    @if($company->logo_path)
+                                                        <img
+                                                            class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
+                                                            src="{{ url('storage/'. $company->logo_path) }}"
+                                                            alt="Logo of {{$company->name}}">
+                                                    @else
+                                                        <h2 class="text-4xl">{{$company->name}}</h2>
+                                                    @endif
+                                                </a>
+                                            </div>
+                                        @endforeach
+                                    @endif
                                 </div>
                             </div>
                             <div class="pb-10">
                                 <h2 class="text-2xl font-semibold mb-5">Silver sponsor</h2>
                                 <div class="flex flex-wrap">
-                                    @foreach(\App\Models\Sponsorship::find(2)->companies as $company)
-                                        <div class="flex items-center justify-start mr-4 mb-4 w-1/3">
-                                            <a href="{{'https://' . $company->website}}"
-                                               class="bg-gray-50 border h-44 p-5 w-full rounded">
-                                                @if($company->logo_path)
-                                                    <img
-                                                        class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
-                                                        src="{{ url('storage/'. $company->logo_path) }}"
-                                                        alt="Logo of {{$company->name}}">
-                                                @else
-                                                    <h2 class="text-4xl">{{$company->name}}</h2>
-                                                @endif
-                                            </a>
-                                        </div>
-                                    @endforeach
+                                    @if(\App\Models\Sponsorship::find(2))
+                                        @foreach(\App\Models\Sponsorship::find(2)->companies as $company)
+                                            <div class="flex items-center justify-start mr-4 mb-4 w-1/3">
+                                                <a href="{{'https://' . $company->website}}"
+                                                   class="bg-gray-50 border h-44 p-5 w-full rounded">
+                                                    @if($company->logo_path)
+                                                        <img
+                                                            class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
+                                                            src="{{ url('storage/'. $company->logo_path) }}"
+                                                            alt="Logo of {{$company->name}}">
+                                                    @else
+                                                        <h2 class="text-4xl">{{$company->name}}</h2>
+                                                    @endif
+                                                </a>
+                                            </div>
+                                        @endforeach
+                                    @endif
                                 </div>
                             </div>
                             <div class="pb-10">
                                 <h2 class="text-xl mb-5 font-semibold">Bronze sponsor</h2>
                                 <div class="flex flex-wrap">
-                                    @foreach(\App\Models\Sponsorship::find(3)->companies as $company)
-                                        <div class="flex items-center justify-start mr-4 mb-4 w-1/4">
-                                            <a href="{{'https://' . $company->website}}"
-                                               class="bg-gray-50 border h-36 px-5 py-3 w-full rounded">
-                                                @if($company->logo_path)
-                                                    <img
-                                                        class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
-                                                        src="{{ url('storage/'. $company->logo_path) }}"
-                                                        alt="Logo of {{$company->name}}">
-                                                @else
-                                                    <h2 class="text-4xl">{{$company->name}}</h2>
-                                                @endif
-                                            </a>
-                                        </div>
-                                    @endforeach
+                                    @if(\App\Models\Sponsorship::find(3))
+                                        @foreach(\App\Models\Sponsorship::find(3)->companies as $company)
+                                            <div class="flex items-center justify-start mr-4 mb-4 w-1/4">
+                                                <a href="{{'https://' . $company->website}}"
+                                                   class="bg-gray-50 border h-36 px-5 py-3 w-full rounded">
+                                                    @if($company->logo_path)
+                                                        <img
+                                                            class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
+                                                            src="{{ url('storage/'. $company->logo_path) }}"
+                                                            alt="Logo of {{$company->name}}">
+                                                    @else
+                                                        <h2 class="text-4xl">{{$company->name}}</h2>
+                                                    @endif
+                                                </a>
+                                            </div>
+                                        @endforeach
+                                    @endif
                                 </div>
                             </div>
                         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
                             We are in IT together Conference
                         </h1>
                         @if($goldSponsorCompany)
-                            <h2 class="mt-5 uppercase font-bold text-sm">
+                            <h2 class="mt-3 pl-1 uppercase font-bold text-lg">
                                 Powered by {{ $goldSponsorCompany->name }}
                             </h2>
                         @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -145,7 +145,10 @@
                 class="absolute inset-0 bg-gradient-to-br from-gradient-light-blue via-gradient-light-pink to-gradient-light-pink dark:from-gradient-dark-blue dark:via-gradient-dark-pink dark:to-gradient-dark-pink opacity-80"></div>
 
             <h2 class="flex justify-center mt-8 mb-5 uppercase text-xl font-montserrat font-bold relative z-10">What to
-                expect on this year's conference?</h2>
+                                                                                                                expect
+                                                                                                                on this
+                                                                                                                year's
+                                                                                                                conference?</h2>
 
             {{-- Cards for speakers, presentations, companies --}}
             <div class="flex flex-wrap justify-between mb-16 lg:px-44 md:px-32 sm:px-24">
@@ -169,8 +172,8 @@
                                 <div class="relative">
                                     <h2 class="text-2xl font-bold">SPEAKERS</h2>
                                     <p class="mt-4">During the conference you will have the chance to meet and speak to
-                                        our
-                                        speakers.</p>
+                                                    our
+                                                    speakers.</p>
                                 </div>
                             </div>
                         </div>
@@ -197,7 +200,7 @@
                                 <div class="relative">
                                     <h2 class="text-2xl font-bold">PRESENTATIONS & WORKSHOPS</h2>
                                     <p class="mt-4">During the conference you can visit a lot of different workshops and
-                                        lectures.</p>
+                                                    lectures.</p>
                                 </div>
                             </div>
                         </div>
@@ -224,113 +227,85 @@
                                 <div class="relative">
                                     <h2 class="text-2xl font-bold">COMPANIES</h2>
                                     <p class="mt-4">During the conference you will have the chance to meet different
-                                        companies.</p>
+                                                    companies.</p>
                                 </div>
                             </div>
                         </div>
                     </a>
                 </div>
             </div>
+            <div class="relative bg-white dark:bg-gray-900 w-full min-h-32 px-4 py-4">
 
-            <!-- Third banner-->
-            <div class="relative">
-                <h2 class="flex justify-center mt-8 mb-5 uppercase text-xl font-montserrat font-bold">Thanks to our
-                    sponsors</h2>
-                <div class="flex flex-wrap justify-center mb-16 text-center">
-                    <div class="text-xl font-montserrat">
-                        <h2>Golden sponsor</h2>
-                        <h2>Silver sponsors</h2>
-                        <h2>Bronze sponsors</h2>
-                    </div>
-                </div>
-                <!-- TODO: Fix when database gets rebuilt -->
-                {{--@if(!$allSponsors->isEmpty())
-                    <div class="isolate flex flex-wrap justify-center w-full gap-3 xl:gap-8 lg:gap-8 md:gap-8 mt-16">
-                        @foreach(\App\Models\SponsorTier::all() as $sponsorTier)
-                            <div class="w-full">
-                                <div class="hidden md:flex xl:flex lg:flex justify-center gap-3">
-                                    @foreach($sponsorTier->teams->where('is_sponsor_approved', 1) as $sponsor)
-                                        <div class="border shadow-lg border-2 w-full @if($allSponsors->count() > 3) px-3 md:w-1/3 lg:w-1/3 xl:w-1/4 @endif @if ($sponsor->sponsorTier->name == 'golden' && $sponsor->is_approved) border-gold block
-                                        @elseif ($sponsor->sponsorTier->name == 'silver' && $sponsor->is_sponsor_approved) border-silver block
-                                        @elseif ($sponsor->sponsorTier->name == 'bronze' && $sponsor->is_sponsor_approved) border-bronze block @endif rounded-lg">
-                                            <a href="{{ $sponsor->website }}" target="_blank">
-                                                <div class="flex flex-col justify-start items-center h-24">
-                                                    @if($sponsor->logo_path)
-                                                        <img alt="{{ $sponsor->name }}"
-                                                             src="{{ url('storage/'. $sponsor->logo_path) }}"
-                                                             class="pt-1 object-scale-down w-full h-14 rounded-lg">
-                                                    @else
-                                                        @php
-                                                            $color = '';
-                                                             if ($sponsor->sponsorTier->name === 'golden' && $sponsor->is_sponsor_approved) $color='#FFD700';
-                                                             elseif ($sponsor->sponsorTier->name === 'silver' && $sponsor->is_sponsor_approved) $color='#C0C0C0';
-                                                             elseif ($sponsor->sponsorTier->name === 'bronze' && $sponsor->is_sponsor_approved) $color='#CD7F32';
-                                                             else $color='#60a5fa'
-                                                        @endphp
-                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none"
-                                                             viewBox="0 0 24 24"
-                                                             stroke-width="1.5"
-                                                             stroke="{{$color}}" aria-hidden="true" class="w-14 h-14">
-                                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                                  d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z"/>
-                                                        </svg>
-                                                    @endif
-                                                    <p class="tracking-tight leading-7 text-base pt-2 text-center dark:text-white">
-                                                        @if (Str::length($sponsor->name) >= 13)
-                                                            {{ substr($sponsor->name, 0, 10) . '...' }}
-                                                        @else
-                                                            {{ $sponsor->name }}
-                                                        @endif
-                                                    </p>
-                                                </div>
-                                            </a>
-                                        </div>
-                                    @endforeach
-                                </div>
-                                <div class="xl:hidden lg:hidden md:hidden grid grid-cols-1 gap-3 content-end">
-                                    @foreach($sponsorTier->teams->where('is_sponsor_approved', 1) as $sponsor)
-                                        <div class="border justify-self-center shadow-lg border-2 w-2/3 px-3 @if ($sponsor->sponsorTier->name == 'golden' && $sponsor->is_approved) border-gold
-                                        @elseif ($sponsor->sponsorTier->name == 'silver' && $sponsor->is_sponsor_approved) border-silver
-                                        @elseif ($sponsor->sponsorTier->name == 'bronze' && $sponsor->is_sponsor_approved) border-bronze @endif rounded-lg">
-                                            <a href="{{ $sponsor->website }}" target="_blank">
-                                                <div class="flex flex-col justify-start items-center h-24">
-                                                    @if($sponsor->logo_path)
-                                                        <img alt="{{ $sponsor->name }}"
-                                                             src="{{ url('storage/'. $sponsor->logo_path) }}"
-                                                             class="pt-1 object-scale-down w-full h-14 rounded-lg">
-                                                    @else
-                                                        @php
-                                                            $color = '';
-                                                             if ($sponsor->sponsorTier->name === 'golden' && $sponsor->is_sponsor_approved) $color='#FFD700';
-                                                             elseif ($sponsor->sponsorTier->name === 'silver' && $sponsor->is_sponsor_approved) $color='#C0C0C0';
-                                                             elseif ($sponsor->sponsorTier->name === 'bronze' && $sponsor->is_sponsor_approved) $color='#CD7F32';
-                                                             else $color='#60a5fa'
-                                                        @endphp
-                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none"
-                                                             viewBox="0 0 24 24"
-                                                             stroke-width="1.5"
-                                                             stroke="{{$color}}" aria-hidden="true" class="w-14 h-14">
-                                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                                  d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z"/>
-                                                        </svg>
-                                                    @endif
-                                                    <p class="tracking-tight leading-7 text-base pt-2 text-center dark:text-white">
-                                                        @if (Str::length($sponsor->name) >= 13)
-                                                            {{ substr($sponsor->name, 0, 10) . '...' }}
-                                                        @else
-                                                            {{ $sponsor->name }}
-                                                        @endif
-                                                    </p>
-                                                </div>
+                <!-- Third banner-->
+                <div>
+                    <h2 class="flex justify-center mt-8 mb-5 uppercase text-3xl font-montserrat font-bold pl-4">A big thank you to our sponsors</h2>
+                    <div class="flex flex-col mb-4 text-left pl-4">
+                        <div class="text-xl font-montserrat">
+                            <div class="py-10">
+                                <h2 class="text-3xl mb-5 font-semibold">Gold sponsor</h2>
+                                <div class="flex flex-wrap">
+                                    @foreach(\App\Models\Sponsorship::find(1)->companies as $company)
+                                        <div class="flex items-center justify-start mr-4 mb-4 w-1/2">
+                                            <a href="{{'https://' . $company->website}}"
+                                               class="bg-gray-50 border h-56 p-5 w-full rounded">
+                                                @if($company->logo_path)
+                                                    <img
+                                                        class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
+                                                        src="{{ url('storage/'. $company->logo_path) }}"
+                                                        alt="Logo of {{$company->name}}">
+                                                @else
+                                                    <h2 class="text-4xl">{{$company->name}}</h2>
+                                                @endif
                                             </a>
                                         </div>
                                     @endforeach
                                 </div>
                             </div>
-                        @endforeach
+                            <div class="pb-10">
+                                <h2 class="text-2xl font-semibold mb-5">Silver sponsor</h2>
+                                <div class="flex flex-wrap">
+                                    @foreach(\App\Models\Sponsorship::find(2)->companies as $company)
+                                        <div class="flex items-center justify-start mr-4 mb-4 w-1/3">
+                                            <a href="{{'https://' . $company->website}}"
+                                               class="bg-gray-50 border h-44 p-5 w-full rounded">
+                                                @if($company->logo_path)
+                                                    <img
+                                                        class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
+                                                        src="{{ url('storage/'. $company->logo_path) }}"
+                                                        alt="Logo of {{$company->name}}">
+                                                @else
+                                                    <h2 class="text-4xl">{{$company->name}}</h2>
+                                                @endif
+                                            </a>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                            <div class="pb-10">
+                                <h2 class="text-xl mb-5 font-semibold">Bronze sponsor</h2>
+                                <div class="flex flex-wrap">
+                                    @foreach(\App\Models\Sponsorship::find(3)->companies as $company)
+                                        <div class="flex items-center justify-start mr-4 mb-4 w-1/4">
+                                            <a href="{{'https://' . $company->website}}"
+                                               class="bg-gray-50 border h-36 px-5 py-3 w-full rounded">
+                                                @if($company->logo_path)
+                                                    <img
+                                                        class="object-contain h-full w-full block dark:text-white transition ease-in-out hover:saturate-[1.25]"
+                                                        src="{{ url('storage/'. $company->logo_path) }}"
+                                                        alt="Logo of {{$company->name}}">
+                                                @else
+                                                    <h2 class="text-4xl">{{$company->name}}</h2>
+                                                @endif
+                                            </a>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                @endif--}}
+                </div>
             </div>
+            <hr>
         </div>
     </div>
 </x-app-layout>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase


### PR DESCRIPTION
# Description

This branch introduces displaying of the sponsors on the welcome page. I tested with this picture as logo for the company. Name the pic `img.png` and put it in the `storage/app/public/logos`. The seeder seeds with it due to some permission issues with $faker->image I did not have time to fix.

![img](https://github.com/HZ-HBO-ICT/it-conference/assets/77020646/af20e442-649e-4e27-bff2-21b5337fa60f)

closes #(issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] Seed and check that the sponsors are visible on the welcome page

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

