### PR TITLE
Feature - Better design crew index pages

### DIFF
--- a/resources/views/crew/booths/index.blade.php
+++ b/resources/views/crew/booths/index.blade.php
@@ -17,7 +17,7 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                 Company Name
                             </th>
-                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400 right-0 sticky w-16">
                                 Created At
                             </th>
                         </tr>

--- a/resources/views/crew/booths/index.blade.php
+++ b/resources/views/crew/booths/index.blade.php
@@ -11,41 +11,59 @@
                     </x-button-link>
                 </x-slot>
                 <x-slot name="content">
-                    @forelse($booths as $index => $booth)
-                        <x-list-section-item class="{{ $booth->is_approved ? 'border-transparent hover:bg-gray-100 ' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 border-apricot-peach-300 dark:border-apricot-peach-600 hover:bg-apricot-peach-200 ' }} border-l-4"
-                                             :url="route('moderator.booths.show', $booth)">
-                            <div class="justify-between flex mt-2">
-                                <div class="flex">
-                                    <div class="text-gray-700 dark:text-white text-m items-center flex">
-                                        <svg
-                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$booth->is_approved ? 'stroke-gray-900 dark:stroke-gray-100 hover:stroke-gray-500' : '' }}"
-                                            xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                            aria-hidden="true">
-                                            <path
-                                                d="M13.5 21v-7.5a.75.75 0 01.75-.75h3a.75.75 0 01.75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349m-16.5 11.65V9.35m0 0a3.001 3.001 0 003.75-.615A2.993 2.993 0 009.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 002.25 1.016c.896 0 1.7-.393 2.25-1.016a3.001 3.001 0 003.75.614m-16.5 0a3.004 3.004 0 01-.621-4.72L4.318 3.44A1.5 1.5 0 015.378 3h13.243a1.5 1.5 0 011.06.44l1.19 1.189a3 3 0 01-.621 4.72m-13.5 8.65h3.75a.75.75 0 00.75-.75V13.5a.75.75 0 00-.75-.75H6.75a.75.75 0 00-.75.75v3.75c0 .415.336.75.75.75z"></path>
-                                        </svg>
-                                        <div class="ml-2 flex-grow">
-                                            <strong>{{$booth->company->name}}</strong>
+                    <table class="min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Company Name
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Created At
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
+                        @forelse($booths as $index => $booth)
+                            <tr class="{{ $booth->is_approved ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 hover:bg-apricot-peach-200' }} cursor-pointer"
+                                onclick="window.location='{{ route('moderator.booths.show', $booth) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
+                                    <div class="flex">
+                                        <div class="text-gray-700 dark:text-white text-m items-center flex">
+                                            <svg
+                                                class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$booth->is_approved ? 'stroke-gray-900 dark:stroke-gray-100 hover:stroke-gray-500' : '' }}"
+                                                xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
+                                                aria-hidden="true">
+                                                <path
+                                                    d="M13.5 21v-7.5a.75.75 0 01.75-.75h3a.75.75 0 01.75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349m-16.5 11.65V9.35m0 0a3.001 3.001 0 003.75-.615A2.993 2.993 0 009.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 002.25 1.016c.896 0 1.7-.393 2.25-1.016a3.001 3.001 0 003.75.614m-16.5 0a3.004 3.004 0 01-.621-4.72L4.318 3.44A1.5 1.5 0 015.378 3h13.243a1.5 1.5 0 011.06.44l1.19 1.189a3 3 0 01-.621 4.72m-13.5 8.65h3.75a.75.75 0 00.75-.75V13.5a.75.75 0 00-.75-.75H6.75a.75.75 0 00-.75.75v3.75c0 .415.336.75.75.75z"></path>
+                                            </svg>
+                                            <div class="ml-2 flex-grow">
+                                                <strong>{{$booth->company->name}}</strong>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="text-sm items-center flex ml-2 dark:text-white">
-                                    <svg
-                                        class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$booth->is_approved ? 'stroke-gray-900 dark:stroke-gray-100 hover:stroke-gray-500' : '' }}"
-                                        xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                        aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round"
-                                              d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                    </svg>
-                                    {{$booth->created_at->format('d/m/Y')}}
-                                </div>
-                            </div>
-                        </x-list-section-item>
-                    @empty
-                        <p class="text-crew-400 text-lg justify-center flex m-12">There are currently no new
-                                                                                  booths waiting on approval.</p>
-                    @endforelse
-
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$booth->is_approved ? 'stroke-gray-900 dark:stroke-white' : '' }}"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        {{ $booth->created_at->format('d/m/Y') }}
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no booths.
+                                </td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
                     <div class="pt-2">
                         {{ $booths->links() }}
                     </div>

--- a/resources/views/crew/companies/index.blade.php
+++ b/resources/views/crew/companies/index.blade.php
@@ -10,26 +10,39 @@
                     <x-button-link href="{{route('moderator.companies.create')}}">
                         {{ __('Invite a company') }}
                     </x-button-link>
-
-                    {{--<x-button-link href="{{route('teams.create')}}" class="ml-2">
-                        {{__('Create a company')}}
-                    </x-button-link>--}}
                 </x-slot>
 
                 <x-slot name="content">
+                    <table class="min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Company Name
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Company Representative
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Created At
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
                         @forelse($companies as $index => $company)
-                        <x-list-section-item class="{{ $company->is_approved ? 'border-transparent hover:bg-gray-100 ' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 border-apricot-peach-300 dark:border-apricot-peach-600 hover:bg-apricot-peach-200 ' }} border-l-4"
-                                :url="route('moderator.companies.show', $company)">
-                                <div class="justify-between flex my-0.5">
+                            <tr class="{{ $company->is_approved ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 hover:bg-apricot-peach-200' }} cursor-pointer"
+                                onclick="window.location='{{ route('moderator.companies.show', $company) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
                                     <div class="flex">
                                         <div class="text-gray-700 dark:text-white text-m items-center flex">
                                             @if($company->logo_path)
                                                 <img class="w-6 h-6 mx-auto my-auto max-w-full block dark:text-white"
-                                                     src="{{ url('storage/'. $company->logo_path) }}" alt="Logo of {{$company->name}}">
+                                                     src="{{ url('storage/'. $company->logo_path) }}"
+                                                     alt="Logo of {{$company->name}}">
                                             @else
                                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                                                      stroke-width="1"
-                                                     stroke="gray" aria-hidden="true" class="w-6 h-6 {{ !$company->is_approved ? 'stroke-gray-900 dark:stroke-white' : 'stroke-apricot-peach-300' }}">
+                                                     stroke="gray" aria-hidden="true"
+                                                     class="w-6 h-6 {{ !$company->is_approved ? 'stroke-gray-900 dark:stroke-white' : 'stroke-apricot-peach-300' }}">
                                                     <path stroke-linecap="round" stroke-linejoin="round"
                                                           d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z"/>
                                                 </svg>
@@ -41,24 +54,36 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="text-sm items-center flex ml-2 dark:text-white">
-                                        <svg class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$company->is_approved ? 'stroke-gray-900 dark:stroke-white' : '' }}" xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                    {{ optional($company->representative)->name }}
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$company->is_approved ? 'stroke-gray-900 dark:stroke-white' : '' }}"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                         </svg>
-                                        {{$company->created_at->format('d/m/Y')}}
+                                        {{ $company->created_at->format('d/m/Y') }}
                                     </div>
-                                </div>
-                            </x-list-section-item>
+                                </td>
+                            </tr>
                         @empty
-                            <p class="text-crew-400 text-lg justify-center flex m-12">There are currently no new presentations waiting on approval.</p>
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no companies.
+                                </td>
+                            </tr>
                         @endforelse
-
+                        </tbody>
+                    </table>
                     <div class="pt-2">
                         {{ $companies->links() }}
                     </div>
-
                 </x-slot>
-
             </x-list-section>
         </div>
     </div>

--- a/resources/views/crew/companies/index.blade.php
+++ b/resources/views/crew/companies/index.blade.php
@@ -22,7 +22,7 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                 Company Representative
                             </th>
-                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400 right-0 sticky w-16">
                                 Created At
                             </th>
                         </tr>

--- a/resources/views/crew/companies/show.blade.php
+++ b/resources/views/crew/companies/show.blade.php
@@ -224,6 +224,45 @@
 
             <x-action-section>
                 <x-slot name="title">
+                    Company Presentations
+                </x-slot>
+
+                <x-slot name="description">
+                    View all presentations related to the company
+                </x-slot>
+
+                <x-slot name="content">
+                        <div class="space-y-2">
+                            @forelse($company->presentations as $presentation)
+                                <a href="{{route('moderator.presentations.show', $presentation)}}"
+                                   class="block bg-white dark:bg-gray-700 p-4 borde rounded-lg shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-300">
+                                    <div class="flex items-center">
+                                        <div class="flex-shrink-0">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                                 stroke-width="1.5" stroke="#E77A50"
+                                                 aria-hidden="true" class="w-6 h-6">
+                                                <path stroke-linecap="round" stroke-linejoin="round"
+                                                      d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"/>
+                                            </svg>
+                                        </div>
+                                        <div class="ml-4">
+                                            <h4 class="text-sm font-semibold">{{ $presentation->name }}</h4>
+                                            <p class="text-xs text-gray-600 dark:text-gray-400">Hosted
+                                                                                                by: {{ $presentation->speakers_name }}</p>
+                                        </div>
+                                    </div>
+                                </a>
+                            @empty
+                                <p>The company has no presentations currently.</p>
+                            @endforelse
+                        </div>
+                </x-slot>
+            </x-action-section>
+
+            <x-section-border/>
+
+            <x-action-section>
+                <x-slot name="title">
                     {{ __('Company Sponsorship Status') }}
                 </x-slot>
 

--- a/resources/views/crew/editions/index.blade.php
+++ b/resources/views/crew/editions/index.blade.php
@@ -15,64 +15,77 @@
                     </x-button-link>
                 </x-slot>
                 <x-slot name="content">
-                    @forelse($editions as $edition)
-                        <x-list-section-item
-                            class="border-transparent hover:bg-gray-100 border-l-4">
-                            <a href="{{ route('moderator.editions.show', $edition) }}" class="block w-full">
-                                <div class="flex justify-between mt-2">
-                                    <div class="flex">
-                                        <div class="text-gray-700 dark:text-white text-m items-center flex">
-                                            <svg
-                                                class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
-                                                xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                                aria-hidden="true">
-                                                <path
-                                                    d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776" />                                                </svg>
-                                            <div class="ml-2 flex-grow">
-                                                <div class="flex gap-4 items-center">
-                                                    <strong>{{ $edition->name }}</strong>
-                                                    @if (Edition::current() && Edition::current()->id == $edition->id)
-                                                        <div
-                                                            class="px-3 py-1 border rounded-full border-emerald-400 border-dashed text-xs font-montserrat text-emerald-400 tracking-wider">
-                                                            ACTIVE
-                                                        </div>
-                                                    @endif
-                                                </div>
-                                                <span
-                                                    class="text-sm text-gray-500">
-                                                        {{ $edition->displayed_state }}
-                                                    </span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="text-sm items-center flex gap-8 ml-2 dark:text-white">
-                                        <div class="flex items-center min-w-max">
-                                            <svg
-                                                class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
-                                                xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                                aria-hidden="true">
-                                                <path stroke-linecap="round" stroke-linejoin="round"
-                                                      d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                            </svg>
-                                            <div class="flex">
-                                                @if (!$edition->start_at || !$edition->end_at)
-                                                    TBD
-                                                @else
-                                                    {{ $edition->start_at->format('d-m-Y H:i') }}
-                                                    —
-                                                    {{ $edition->end_at->format('d-m-Y H:i') }}
+                    <table class="table-fixed min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Edition
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Date
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
+                        @forelse($editions as $edition)
+                            <tr class="hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+                                onclick="window.location='{{ route('moderator.editions.show', $edition) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
+                                    <div class="text-gray-700 dark:text-white text-m items-center flex">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
+                                            xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path
+                                                d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776"/>
+                                        </svg>
+                                        <div class="ml-2 flex-grow">
+                                            <div class="flex gap-4 items-center">
+                                                <strong>{{ $edition->name }}</strong>
+                                                @if (Edition::current() && Edition::current()->id == $edition->id)
+                                                    <div
+                                                        class="px-3 py-1 border rounded-full border-emerald-400 border-dashed text-xs font-montserrat text-emerald-400 tracking-wider">
+                                                        ACTIVE
+                                                    </div>
                                                 @endif
                                             </div>
+                                            <span
+                                                class="text-sm text-gray-500">
+                                                        {{ $edition->displayed_state }}
+                                            </span>
                                         </div>
                                     </div>
-                                </div>
-                            </a>
-                        </x-list-section-item>
-                    @empty
-                        <p class="text-apricot-peach-400 text-lg justify-center flex m-12">
-                            There are currently no editions
-                        </p>
-                    @endforelse
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center min-w-max">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
+                                            xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        <div class="flex">
+                                            @if (!$edition->start_at || !$edition->end_at)
+                                                TBD
+                                            @else
+                                                {{ $edition->start_at->format('d-m-Y H:i') }}
+                                                —
+                                                {{ $edition->end_at->format('d-m-Y H:i') }}
+                                            @endif
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no editions.
+                                </td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
                 </x-slot>
             </x-list-section>
         </div>

--- a/resources/views/crew/faqs/index.blade.php
+++ b/resources/views/crew/faqs/index.blade.php
@@ -19,7 +19,7 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                 Frequently Asked Question
                             </th>
-                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400 right-0 sticky w-16">
                                 Created At
                             </th>
                         </tr>

--- a/resources/views/crew/faqs/index.blade.php
+++ b/resources/views/crew/faqs/index.blade.php
@@ -13,36 +13,57 @@
                     </x-slot>
                 @endcan
                 <x-slot name="content">
-                    @forelse($faqs as $index => $faq)
-                        <x-list-section-item
-                            class="border-transparent hover:bg-gray-100 border-l-4"
-                            :url="route('moderator.faqs.show', $faq)">
-                            <div class="justify-between flex mt-2">
-                                <div class="flex">
-                                    <div class="text-gray-700 dark:text-white text-m items-center flex">
-                                        <svg class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
-                                        </svg>
-                                        <div class="ml-2 flex-grow">
-                                            <strong>{{$faq->question}}</strong>
+                    <table class="table-fixed min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Frequently Asked Question
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Created At
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
+                        @forelse($faqs as $index => $faq)
+                            <tr class="hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+                                onclick="window.location='{{ route('moderator.faqs.show', $faq) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
+                                    <div class="flex">
+                                        <div class="flex">
+                                            <div class="text-gray-700 dark:text-white text-m items-center flex">
+                                                <svg class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+                                                </svg>
+                                                <div class="ml-2 flex-grow">
+                                                    <strong>{{$faq->question}}</strong>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="text-sm items-center flex ml-2 dark:text-white">
-                                    <svg
-                                        class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
-                                        xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                        aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round"
-                                              d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                    </svg>
-                                    {{$faq->created_at->format('d/m/Y')}}
-                                </div>
-                            </div>
-                        </x-list-section-item>
-                    @empty
-                        <p class="text-crew-400 text-lg justify-center flex m-12">There are currently no FAQs</p>
-                    @endforelse
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        {{ $faq->created_at->format('d/m/Y') }}
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no FAQs.
+                                </td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
                 </x-slot>
             </x-list-section>
         </div>

--- a/resources/views/crew/presentations/index.blade.php
+++ b/resources/views/crew/presentations/index.blade.php
@@ -11,47 +11,63 @@
                     </x-button-link>
                 </x-slot>
                 <x-slot name="content">
-                    <ul role="list">
+                    <table class="min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Presentation Name
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Company
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Created At
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
                         @forelse($presentations as $index => $presentation)
-                            <x-list-section-item class="{{ $presentation->is_approved ? 'border-transparent hover:bg-gray-100 ' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 border-apricot-peach-300 dark:border-apricot-peach-600 hover:bg-apricot-peach-200 ' }} border-l-4">
-                            <a href="{{route('moderator.presentations.show', $presentation)}}" class="block">
-                                    <div class="justify-between flex mt-2">
-                                        <div class="flex">
-                                            <div class="text-gray-700 dark:text-white text-m items-center flex">
-                                                <svg
-                                                    class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-300 {{ !$presentation->is_approved ? 'stroke-gray-900 dark:stroke-white' : 'stroke-apricot-peach-300' }}"
-                                                    xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                                    aria-hidden="true">
-                                                    <path
-                                                        d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
-                                                </svg>
-                                                <div class="ml-2 flex-grow">
-                                                    <strong>{{$presentation->name}}</strong>
-                                                    <br/>
-                                                    <span
-                                                        class="text-sm text-gray-500">{{ $presentation->speakernames }}</span>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="text-sm items-center flex ml-2 dark:text-white">
-                                            <svg
-                                                class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$presentation->is_approved ? 'stroke-gray-900 dark:stroke-white' : '' }}"
-                                                xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                                aria-hidden="true">
-                                                <path stroke-linecap="round" stroke-linejoin="round"
-                                                      d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                            </svg>
-                                            {{$presentation->created_at->format('d/m/Y')}}
+                            <tr class="{{ $presentation->is_approved ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 hover:bg-apricot-peach-200' }} cursor-pointer"
+                                onclick="window.location='{{ route('moderator.presentations.show', $presentation) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-300 {{ !$presentation->is_approved ? 'stroke-gray-900 dark:stroke-white' : 'stroke-apricot-peach-300' }}"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path
+                                                d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6"></path>
+                                        </svg>
+                                        <div class="ml-2">
+                                            <strong>{{ $presentation->name }}</strong>
                                         </div>
                                     </div>
-                                </a>
-                            </x-list-section-item>
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                    {{ optional($presentation->company)->name }}
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$presentation->is_approved ? 'stroke-gray-900 dark:stroke-white' : '' }}"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        {{ $presentation->created_at->format('d/m/Y') }}
+                                    </div>
+                                </td>
+                            </tr>
                         @empty
-                            <p class="text-crew-400 text-lg justify-center flex m-12">There are currently no new
-                                                                                      presentations waiting on
-                                                                                      approval.</p>
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no new presentations waiting on approval.
+                                </td>
+                            </tr>
                         @endforelse
-                    </ul>
+                        </tbody>
+                    </table>
                     <div class="pt-2">
                         {{ $presentations->links() }}
                     </div>

--- a/resources/views/crew/presentations/index.blade.php
+++ b/resources/views/crew/presentations/index.blade.php
@@ -20,7 +20,7 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                 Company
                             </th>
-                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400 right-0 sticky w-16">
                                 Created At
                             </th>
                         </tr>

--- a/resources/views/crew/rooms/index.blade.php
+++ b/resources/views/crew/rooms/index.blade.php
@@ -19,7 +19,7 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                 Room Name
                             </th>
-                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider right-0 sticky w-16 dark:text-gray-400">
                                 Created At
                             </th>
                         </tr>
@@ -48,7 +48,7 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white right-0 sticky ">
                                     <div class="flex items-center">
                                         <svg
                                             class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"

--- a/resources/views/crew/rooms/index.blade.php
+++ b/resources/views/crew/rooms/index.blade.php
@@ -13,43 +13,63 @@
                     </x-slot>
                 @endcan
                 <x-slot name="content">
-                    @forelse($rooms as $index => $room)
-                        <x-list-section-item
-                            class="border-transparent hover:bg-gray-100 border-l-4"
-                            :url="route('moderator.rooms.show', $room)">
-                            <div class="justify-between flex mt-2">
-                                <div class="flex">
-                                    <div class="text-gray-700 dark:text-white text-m items-center flex">
-                                        <svg
-                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
-                                            xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                            aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                  d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z"/>
-                                            <path
-                                                d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z"></path>
-                                        </svg>
-                                        <div class="ml-2 flex-grow">
-                                            <strong>{{$room->name}}</strong>
+                    <table class="table-fixed min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Room Name
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Created At
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
+                        @forelse($rooms as $index => $room)
+                            <tr class="hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+                                onclick="window.location='{{ route('moderator.rooms.show', $room) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
+                                    <div class="flex">
+                                        <div class="flex">
+                                            <div class="text-gray-700 dark:text-white text-m items-center flex">
+                                                <svg
+                                                    class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
+                                                    xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
+                                                    aria-hidden="true">
+                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                          d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z"/>
+                                                    <path
+                                                        d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                                </svg>
+                                                <div class="ml-2 flex-grow">
+                                                    <strong>{{$room->name}}</strong>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="text-sm items-center flex ml-2 dark:text-white">
-                                    <svg
-                                        class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
-                                        xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                        aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round"
-                                              d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                    </svg>
-                                    {{$room->created_at->format('d/m/Y')}}
-                                </div>
-                            </div>
-                        </x-list-section-item>
-                    @empty
-                        <p class="text-crew-400 text-lg justify-center flex m-12">There are currently no rooms</p>
-                    @endforelse
-
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        {{ $room->created_at->format('d/m/Y') }}
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no rooms.
+                                </td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
                 </x-slot>
             </x-list-section>
         </div>

--- a/resources/views/crew/sponsorships/index.blade.php
+++ b/resources/views/crew/sponsorships/index.blade.php
@@ -24,7 +24,7 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                 Company Name
                             </th>
-                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400 right-0 sticky w-16">
                                 Created At
                             </th>
                         </tr>

--- a/resources/views/crew/sponsorships/index.blade.php
+++ b/resources/views/crew/sponsorships/index.blade.php
@@ -18,47 +18,64 @@
                     @endcan
                 @endif
                 <x-slot name="content">
-                    @forelse($companies as $index => $company)
-                        <x-list-section-item class="{{ $company->is_sponsorship_approved ? 'border-transparent hover:bg-gray-100 ' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 border-apricot-peach-300 dark:border-apricot-peach-600 hover:bg-apricot-peach-200 ' }} border-l-4"
-                            :url="route('moderator.sponsorships.show', $company)">
-                            <div class="justify-between flex mt-2">
-                                <div class="flex">
-                                    <div class="text-gray-700 dark:text-white text-m items-center flex">
-                                        @if($company->logo_path)
-                                            <img class="w-6 h-6 mx-auto my-auto max-w-full block dark:text-white"
-                                                 src="{{ url('storage/'. $company->logo_path) }}"
-                                                 alt="Logo of {{$company->name}}">
-                                        @else
-                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                                 stroke-width="1"
-                                                 stroke="gray" aria-hidden="true" class="w-6 h-6 {{$company->is_sponsorship_approved ? 'stroke-apricot-peach-300' : 'stroke-gray-800'}}">
-                                                <path stroke-linecap="round" stroke-linejoin="round"
-                                                      d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z"/>
-                                            </svg>
-
-                                        @endif
-                                        <div class="ml-2 flex-grow">
-                                            <strong>{{$company->name}}</strong>
+                    <table class="min-w-full divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Company Name
+                            </th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                Created At
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y-4 divide-white dark:divide-gray-700">
+                        @forelse($companies as $index => $company)
+                            <tr class="{{ $company->is_sponsorship_approved ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : 'bg-apricot-peach-400 bg-opacity-30 dark:bg-opacity-20 hover:bg-apricot-peach-200' }} cursor-pointer"
+                                onclick="window.location='{{ route('moderator.sponsorships.show', $company) }}'">
+                                <td class="px-4 py-4 whitespace-nowrap text-gray-700 dark:text-white">
+                                    <div class="flex">
+                                        <div class="text-gray-700 dark:text-white text-m items-center flex">
+                                            @if($company->logo_path)
+                                                <img class="w-6 h-6 mx-auto my-auto max-w-full block dark:text-white"
+                                                     src="{{ url('storage/'. $company->logo_path) }}"
+                                                     alt="Logo of {{$company->name}}">
+                                            @else
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                                     stroke-width="1"
+                                                     stroke="gray" aria-hidden="true" class="w-6 h-6 {{$company->is_sponsorship_approved ? 'stroke-apricot-peach-300' : 'stroke-gray-800'}}">
+                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                          d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z"/>
+                                                </svg>
+                                            @endif
+                                            <div class="ml-2 flex-grow">
+                                                <strong>{{$company->name}}</strong>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="text-sm items-center flex ml-2 dark:text-white">
-                                    <svg
-                                        class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$company->is_sponsorship_approved ? 'stroke-gray-900 dark:stroke-white' : ''  }}"
-                                        xlmns="http://www.w3.org/2000/svg" viewbox="0 0 23 23" fill="none"
-                                        aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round"
-                                              d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                    </svg>
-                                    {{$company->created_at->format('d/m/Y')}}
-                                </div>
-                            </div>
-                        </x-list-section-item>
-                    @empty
-                        <p class="text-crew-400 text-lg justify-center flex m-12">There are currently no new
-                                                                                  presentations waiting on approval.</p>
-                    @endforelse
-
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-white">
+                                    <div class="flex items-center">
+                                        <svg
+                                            class="shrink-0 w-6 h-6 mr-1.5 block stroke-apricot-peach-400 {{ !$company->is_sponsorship_approved ? 'stroke-gray-900 dark:stroke-white' : '' }}"
+                                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" fill="none"
+                                            aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        {{ $company->created_at->format('d/m/Y') }}
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-4 py-2 text-center text-gray-500 dark:text-gray-300">
+                                    There are currently no sponsorships.
+                                </td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
                     <div class="pt-2">
                         {{ $companies->links() }}
                     </div>


### PR DESCRIPTION
# Description

This branch introduces design changes on the index pages for the crew. The general layout of the list of entities is changed (now it's made under table) to help with providing more details. Also now the view of the route `moderator.companies.show` includes the presentations of the company.

closes #556 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [x] Check `crew.companies.index` and ensure that the data needed is there
- [x] Check `crew.presentations.index` and ensure that the data needed is there
- [x] Check `crew.booths.index` and ensure that the data needed is there
- [x] Check `crew.sponsorships.index` and ensure that the data needed is there
- [x] Check `crew.rooms.index` and ensure that the data needed is there
- [x] Check `crew.faqs.index` and ensure that the data needed is there
- [x] Check `crew.editions.index` and ensure that the data needed is there

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

