### PR TITLE
Bugfix - Time of the seeded edition

### DIFF
--- a/app/Livewire/Forms/EditionForm.php
+++ b/app/Livewire/Forms/EditionForm.php
@@ -47,8 +47,8 @@ class EditionForm extends Form
         $this->edition = $edition;
 
         $this->name = $edition->name;
-        $this->start_at = $edition->start_at->format('Y-m-d\TH:i:s');
-        $this->end_at = $edition->end_at->format('Y-m-d\TH:i:s');
+        $this->start_at = Carbon::parse($edition->start_at)->format('Y-m-d H:i');
+        $this->end_at = Carbon::parse($edition->end_at)->format('Y-m-d H:i');
         $this->lecture_duration = $edition->lecture_duration;
         $this->workshop_duration = $edition->workshop_duration;
         $this->upperBoundary = Carbon::now()->addYears(2);

--- a/database/seeders/EditionSeeder.php
+++ b/database/seeders/EditionSeeder.php
@@ -16,30 +16,30 @@ class EditionSeeder extends Seeder
     public function run(): void
     {
         Edition::create([
-            'name' => 'We are in IT together Conference ' . date('Y'),
-            'start_at' => date('Y-m-d H:i:s', strtotime('2024-11-18 09:00:00')),
-            'end_at' => date('Y-m-d H:i:s', strtotime('2024-11-18 17:00:00')),
+            'name' => 'We are in IT together Conference ' . Carbon::now()->year,
+            'start_at' => Carbon::now()->addMonths(2)->setTime(9, 0),
+            'end_at' => Carbon::now()->addMonths(2)->setTime(17, 0),
         ]);
 
         EditionEvent::create([
             'edition_id' => 1,
             'event_id' => 1,
-            'start_at' => Carbon::now(),
-            'end_at' => Carbon::now()->addWeeks(2),
+            'start_at' => Carbon::today(),
+            'end_at' => Carbon::today()->addWeeks(3),
         ]);
 
         EditionEvent::create([
             'edition_id' => 1,
             'event_id' => 2,
-            'start_at' => Carbon::now(),
-            'end_at' => Carbon::now()->addWeeks(2),
+            'start_at' => Carbon::today(),
+            'end_at' => Carbon::today()->addWeeks(3),
         ]);
 
         EditionEvent::create([
             'edition_id' => 1,
             'event_id' => 3,
-            'start_at' => Carbon::now(),
-            'end_at' => Carbon::now()->addWeeks(2),
+            'start_at' => Carbon::today(),
+            'end_at' => Carbon::today()->addWeeks(3),
         ]);
     }
 }


### PR DESCRIPTION
# Description

There was a bug discovered by @v-stamenova about the edition (and event) dates not being editable, and I figured out it was because of the way the app seeds them (it took seconds into account). So this PR fixes these issues.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] Seed the database and verify that you can successfully edit all the dates related to the edition.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

