### PR TITLE
Feature - Programme released stage and setting up default opening/closing presentations

### DIFF
--- a/app/Console/Commands/SetupStage.php
+++ b/app/Console/Commands/SetupStage.php
@@ -22,7 +22,7 @@ class SetupStage extends Command
      */
     protected $description = 'Set up the database for a specific conference stage';
 
-    private array $availableStages = ['initial', 'company-registration', 'participant-registration'];
+    private array $availableStages = ['initial', 'company-registration', 'participant-registration', 'programme-released'];
 
     /**
      * Execute the console command.
@@ -57,6 +57,9 @@ class SetupStage extends Command
                     break;
                 case 'participant-registration':
                     Artisan::call('db:seed --class=ParticipantRegistrationSeeder');
+                    break;
+                case 'programme-released':
+                    Artisan::call('db:seed --class=ProgrammeReleasedSeeder');
                     break;
                 default:
                     throw new Exception('Invalid Stage was given');

--- a/database/seeders/InitialSeeder.php
+++ b/database/seeders/InitialSeeder.php
@@ -2,8 +2,10 @@
 
 namespace Database\Seeders;
 
+use App\Models\DefaultPresentation;
 use App\Models\Edition;
 use App\Models\EditionEvent;
+use App\Models\Timeslot;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\User;
@@ -33,5 +35,26 @@ class InitialSeeder extends Seeder
         // 3. Retrieve the created edition and activate it
         $edition = Edition::first();
         $edition->activate();
+
+        // 4. Create default opening and closing presentations
+        DefaultPresentation::create([
+            'name' => 'Opening presentation',
+            'description' => 'This is the opening presentation!',
+            'start' => '08:00:00',
+            'end' => '9:30:00',
+            'type' => 'opening',
+            'room_id' => '1',
+        ]);
+
+        DefaultPresentation::create([
+            'name' => 'Closing presentation',
+            'description' => 'This is the closing presentation!',
+            'start' => '16:00:00',
+            'end' => '17:30:00',
+            'type' => 'closing',
+            'room_id' => '1',
+        ]);
+
+        Timeslot::generateTimeslots();
     }
 }

--- a/database/seeders/ProgrammeReleasedSeeder.php
+++ b/database/seeders/ProgrammeReleasedSeeder.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Actions\Schedule\PresentationAllocationHelper;
+use App\Enums\ApprovalStatus;
+use App\Events\FinalProgrammeReleased;
+use App\Models\DefaultPresentation;
+use App\Models\Edition;
+use App\Models\Presentation;
+use App\Models\Room;
+use App\Models\Timeslot;
+use DateTime;
+use DateTimeZone;
+use Illuminate\Database\Seeder;
+
+class ProgrammeReleasedSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        activity()->withoutLogs(function () {
+            $this->call(ParticipantRegistrationSeeder::class);
+
+            $opening = DefaultPresentation::create([
+                'name' => 'Opening presentation',
+                'description' => 'This is the opening presentation!',
+                'start' => '08:00:00',
+                'end' => '9:30:00',
+                'type' => 'opening',
+                'room_id' => '1',
+            ]);
+
+            $closing = DefaultPresentation::create([
+                'name' => 'Closing presentation',
+                'description' => 'This is the closing presentation!',
+                'start' => '16:00:00',
+                'end' => '17:30:00',
+                'type' => 'closing',
+                'room_id' => '1',
+            ]);
+
+            Timeslot::generateTimeslots();
+
+            Presentation::all()->each(function (Presentation $presentation) {
+               $presentation->update(['approval_status' => ApprovalStatus::APPROVED->value]);
+            });
+
+            $timezone = new DateTimeZone('Europe/Amsterdam');
+            $currentTime = new DateTime($opening->end, $timezone);
+            $closingTime = new DateTime($closing->start, $timezone);
+            $room_id = 1;
+            $helper = new PresentationAllocationHelper();
+
+            $edition = Edition::current();
+            $lecture_duration = $edition->lecture_duration ?? 30;
+            $workshop_duration = $edition->workshop_duration ?? 120;
+
+            foreach (Presentation::all() as $presentation) {
+                $timeslot = $helper->findTimeslotByStartingTime($currentTime);
+
+                $presentation->update([
+                    'room_id' => $room_id,
+                    'timeslot_id' => $timeslot->id,
+                    'start' => $currentTime->format('H:i'),
+                ]);
+
+                if ($presentation->type == 'lecture') {
+                    $currentTime->modify("+{$lecture_duration} minutes");
+                } else {
+                    $currentTime->modify("+{$workshop_duration} minutes");
+                }
+
+                if ($room_id == Room::count()) {
+                  break;
+                } else if ($currentTime >= $closingTime) {
+                    $room_id += 1;
+                    $currentTime = new DateTime($opening->end, $timezone);
+                }
+            }
+
+            FinalProgrammeReleased::dispatch();
+        });
+    }
+}

--- a/database/seeders/ProgrammeReleasedSeeder.php
+++ b/database/seeders/ProgrammeReleasedSeeder.php
@@ -45,7 +45,7 @@ class ProgrammeReleasedSeeder extends Seeder
             Timeslot::generateTimeslots();
 
             Presentation::all()->each(function (Presentation $presentation) {
-               $presentation->update(['approval_status' => ApprovalStatus::APPROVED->value]);
+                $presentation->update(['approval_status' => ApprovalStatus::APPROVED->value]);
             });
 
             $timezone = new DateTimeZone('Europe/Amsterdam');
@@ -74,8 +74,8 @@ class ProgrammeReleasedSeeder extends Seeder
                 }
 
                 if ($room_id == Room::count()) {
-                  break;
-                } else if ($currentTime >= $closingTime) {
+                    break;
+                } elseif ($currentTime >= $closingTime) {
                     $room_id += 1;
                     $currentTime = new DateTime($opening->end, $timezone);
                 }

--- a/database/seeders/ProgrammeReleasedSeeder.php
+++ b/database/seeders/ProgrammeReleasedSeeder.php
@@ -24,25 +24,8 @@ class ProgrammeReleasedSeeder extends Seeder
         activity()->withoutLogs(function () {
             $this->call(ParticipantRegistrationSeeder::class);
 
-            $opening = DefaultPresentation::create([
-                'name' => 'Opening presentation',
-                'description' => 'This is the opening presentation!',
-                'start' => '08:00:00',
-                'end' => '9:30:00',
-                'type' => 'opening',
-                'room_id' => '1',
-            ]);
-
-            $closing = DefaultPresentation::create([
-                'name' => 'Closing presentation',
-                'description' => 'This is the closing presentation!',
-                'start' => '16:00:00',
-                'end' => '17:30:00',
-                'type' => 'closing',
-                'room_id' => '1',
-            ]);
-
-            Timeslot::generateTimeslots();
+            $opening = optional(DefaultPresentation::opening());
+            $closing = optional(DefaultPresentation::closing());
 
             Presentation::all()->each(function (Presentation $presentation) {
                 $presentation->update(['approval_status' => ApprovalStatus::APPROVED->value]);


### PR DESCRIPTION
# Description

This branch introduces a new seeder (`ProgrammeReleasedSeeder`) that can be called via the support function `sail artisan db:setup programme-released`. It approves, schedules all presentations and releases the programme.

It also introduces the automatic seeding of the default presentation (opening and closing) to save some time.

closes #644, #651 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## What needs to be tested

Test that when you call run the function it does all of the following actions:
- [ ] Approves all presentations
- [ ] Schedules all presentations
- [ ] Releases the programme

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

