### PR TITLE
changed edition events to only be allowed within the 12 months before…

### DIFF
--- a/app/Livewire/Forms/EditionEventForm.php
+++ b/app/Livewire/Forms/EditionEventForm.php
@@ -18,14 +18,14 @@ class EditionEventForm extends Form
 
     public $lowerBoundary;
 
-    #[Validate(['required', 'date', 'after_or_equal:today', 'before:upperBoundary'])]
+    #[Validate(['required', 'date', 'after:lowerBoundary', 'before:upperBoundary'])]
     public $start_at;
 
     #[Validate(['required', 'date', 'after:start_at', 'before:upperBoundary'])]
     public $end_at;
 
     protected $messages = [
-        'start_at.after' => 'The start date should be at least from today.',
+        'start_at.after' => 'The start date should be within the 12 months before the edition',
         'start_at.before' => 'The start date should be earlier than the start date of edition.',
         'end_at.after' => 'The end date should be later than start date.',
         'end_at.before' => 'The end date should be be earlier than the start date of edition.',
@@ -46,7 +46,7 @@ class EditionEventForm extends Form
         $this->start_at = $editionEvent->start_at ? $editionEvent->start_at->format('Y-m-d') : '';
         $this->end_at = $editionEvent->end_at ? $editionEvent->end_at->format('Y-m-d') : '';
         $this->upperBoundary = $this->edition->start_at;
-        $this->lowerBoundary = Carbon::now()->subMonths(2);
+        $this->lowerBoundary = $this->edition->start_at->subMonths(12);
     }
 
     /**


### PR DESCRIPTION
# Description

Previously, when editing edition events, validation would fail if the event's start date was in the past. For example, if you created an event with a start date in January, you wouldn't be able to edit or even extend the end date because the validation would still fail because of the startdate (since then it's in the past)

with the current changes, as long as the start-date of the event is within 12 months before the start of the edition, validation works

closes #594 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] *Example* Add a user to the database

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

