### PR TITLE
Bugfix - Change event dates based on stage

### DIFF
--- a/database/seeders/CompanyRegistrationSeeder.php
+++ b/database/seeders/CompanyRegistrationSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Models\Edition;
+use Carbon\Carbon;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -20,6 +22,16 @@ class CompanyRegistrationSeeder extends Seeder
 
             // 2. Create a few companies with sponsors and presentations
             $this->call(CompanySeeder::class);
+
+            // 3. Change the event starting date so that the company registration is open
+            optional(Edition::current())->getEvent('Company registration')->update([
+                'start_at' => Carbon::today(),
+            ]);
+
+            // 4. Change the presentation request starting date so that companies can request presentations
+            optional(Edition::current())->getEvent('Presentation request')->update([
+                'start_at' => Carbon::today(),
+            ]);
         });
     }
 }

--- a/database/seeders/ParticipantRegistrationSeeder.php
+++ b/database/seeders/ParticipantRegistrationSeeder.php
@@ -2,8 +2,10 @@
 
 namespace Database\Seeders;
 
+use App\Models\Edition;
 use App\Models\Presentation;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -40,6 +42,11 @@ class ParticipantRegistrationSeeder extends Seeder
                     $user->joinPresentation($presentation);
                 }
             }
+
+            // 3. Change the event starting date so that the participant registration is open
+            optional(Edition::current())->getEvent('Participant registration')->update([
+                'start_at' => Carbon::today(),
+            ]);
         });
     }
 }


### PR DESCRIPTION
# Description

This branch introduces fix on the issue in which the stages `company-registration` and `participant-registration` did not modify the event dates, therefore the company nor the participant registration was open despite the seeded stage. The request presentation event starts alongside the company registration one.

closes #655 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] When you run `sail artisan db:setup initial` no registration is open
- [ ] When you run `sail artisan db:setup company-registration` the company registration is open and you can register as a company and (once the company is approved) you can request a presentation
- [ ] When you run `sail artisan db:setup participant-registration` the participant registration is open and you can register as such and you can request a presentation; NOTE: the company registration won't be closed

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

