### PR TITLE
Bugfix - Unclear process in editions

### DIFF
--- a/app/Livewire/Forms/EditionForm.php
+++ b/app/Livewire/Forms/EditionForm.php
@@ -24,12 +24,6 @@ class EditionForm extends Form
     #[Validate(['required', 'date', 'after:start_at', 'before:upperBoundary'])]
     public $end_at;
 
-    #[Validate(['required', 'numeric', 'min:1', 'max:120'])]
-    public $lecture_duration;
-
-    #[Validate('required', 'numeric', 'min:1', 'max:180')]
-    public $workshop_duration;
-
     protected $messages = [
         'start_at.after' => 'The start date should be at least a month from now.',
         'start_at.before' => 'The start date should be two years from now at latest.',
@@ -49,8 +43,6 @@ class EditionForm extends Form
         $this->name = $edition->name;
         $this->start_at = Carbon::parse($edition->start_at)->format('Y-m-d H:i');
         $this->end_at = Carbon::parse($edition->end_at)->format('Y-m-d H:i');
-        $this->lecture_duration = $edition->lecture_duration;
-        $this->workshop_duration = $edition->workshop_duration;
         $this->upperBoundary = Carbon::now()->addYears(2);
         $this->lowerBoundary = Carbon::now()->addMonth();
     }

--- a/app/Models/Edition.php
+++ b/app/Models/Edition.php
@@ -93,9 +93,7 @@ class Edition extends Model
         return [
             'name' => 'required|unique:editions|max:255',
             'start_at' => 'required|date|after:' . Carbon::now()->addMonth() . '|before:' . Carbon::now()->addYears(2),
-            'end_at' => 'required|date|after:start_at|before:' . Carbon::now()->addYears(2),
-            'lecture_duration' => 'required|numeric|min:1|max:120',
-            'workshop_duration' => 'required|numeric|min:1|max:180'
+            'end_at' => 'required|date|after:start_at|before:' . Carbon::now()->addYears(2)
         ];
     }
 

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -116,26 +116,6 @@ class Presentation extends Model
     }
 
     /**
-     * Returns the duration of the lecture based on the Edition
-     *
-     * @return \Illuminate\Database\Eloquent\HigherOrderBuilderProxy|mixed
-     */
-    public static function lectureDuration()
-    {
-        return Edition::current()->lecture_duration;
-    }
-
-    /**
-     * Returns the duration of the workshops based on the Edition
-     *
-     * @return \Illuminate\Database\Eloquent\HigherOrderBuilderProxy|mixed
-     */
-    public static function workshopDuration()
-    {
-        return Edition::current()->workshop_duration;
-    }
-
-    /**
      * Establishes a relationship between the presentation
      * and its difficulty
      * @return BelongsTo
@@ -344,9 +324,7 @@ class Presentation extends Model
     public function duration(): Attribute
     {
         return Attribute::make(
-            get: fn() => $this->type == 'workshop'
-                ? Presentation::workshopDuration()
-                : Presentation::lectureDuration()
+            get: fn() => $this->presentationType->duration,
         );
     }
 
@@ -394,7 +372,7 @@ class Presentation extends Model
         return $this->is($presentation) &&
             $this->name == $presentation->name &&
             $this->description == $presentation->description &&
-            $this->type == $presentation->type &&
+            $this->presentationType->id == $presentation->presentationType->id &&
             $this->max_participants == $presentation->max_participants &&
             $this->difficulty->id == $presentation->difficulty->id;
     }

--- a/database/migrations/2023_09_13_130057_create_editions_table.php
+++ b/database/migrations/2023_09_13_130057_create_editions_table.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * @deprecated lecture_duration Now the presentation types are flexible so it's not needed
+     * @deprecated workshop_duration Now the presentation types are flexible so it's not needed
      * Run the migrations.
      */
     public function up(): void

--- a/database/seeders/ProgrammeReleasedSeeder.php
+++ b/database/seeders/ProgrammeReleasedSeeder.php
@@ -37,10 +37,6 @@ class ProgrammeReleasedSeeder extends Seeder
             $room_id = 1;
             $helper = new PresentationAllocationHelper();
 
-            $edition = Edition::current();
-            $lecture_duration = $edition->lecture_duration ?? 30;
-            $workshop_duration = $edition->workshop_duration ?? 120;
-
             foreach (Presentation::all() as $presentation) {
                 $timeslot = $helper->findTimeslotByStartingTime($currentTime);
 
@@ -50,11 +46,7 @@ class ProgrammeReleasedSeeder extends Seeder
                     'start' => $currentTime->format('H:i'),
                 ]);
 
-                if ($presentation->type == 'lecture') {
-                    $currentTime->modify("+{$lecture_duration} minutes");
-                } else {
-                    $currentTime->modify("+{$workshop_duration} minutes");
-                }
+                $currentTime->modify("+{$presentation->presentationType->duration} minutes");
 
                 if ($room_id == Room::count()) {
                     break;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1633,12 +1633,6 @@ parameters:
 			path: app/Livewire/Forms/EditionForm.php
 
 		-
-			message: '#^Property App\\Livewire\\Forms\\EditionForm\:\:\$lecture_duration has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/Livewire/Forms/EditionForm.php
-
-		-
 			message: '#^Property App\\Livewire\\Forms\\EditionForm\:\:\$lowerBoundary has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -1664,12 +1658,6 @@ parameters:
 
 		-
 			message: '#^Property App\\Livewire\\Forms\\EditionForm\:\:\$upperBoundary has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/Livewire/Forms/EditionForm.php
-
-		-
-			message: '#^Property App\\Livewire\\Forms\\EditionForm\:\:\$workshop_duration has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: app/Livewire/Forms/EditionForm.php
@@ -2965,12 +2953,6 @@ parameters:
 			path: app/Models/Presentation.php
 
 		-
-			message: '#^Cannot access property \$lecture_duration on object\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Models/Presentation.php
-
-		-
 			message: '#^Cannot access property \$max_participants on App\\Models\\Room\|null\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -2978,12 +2960,6 @@ parameters:
 
 		-
 			message: '#^Cannot access property \$name on App\\Models\\User\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Models/Presentation.php
-
-		-
-			message: '#^Cannot access property \$workshop_duration on object\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: app/Models/Presentation.php

--- a/resources/views/crew/editions/create.blade.php
+++ b/resources/views/crew/editions/create.blade.php
@@ -24,14 +24,14 @@
                                 <x-input
                                     id="name"
                                     name="name"
-                                    value="We are in IT together Conference {{ date('Y') + 1 }}"
+                                    value="We are in IT together Conference {{ date('Y') }}"
                                     type="text"
                                     class="mt-1 block w-full"
                                 />
                                 <x-input-error for="name" class="mt-2"/>
                             </div>
                             <div class="col-span-6 sm:col-span-4 pb-4">
-                                <x-label for="start_at" value="Start Date" class="after:content-['*'] after:text-red-500"/>
+                                <x-label for="start_at" value="Starting time of the event" class="after:content-['*'] after:text-red-500"/>
                                 <input
                                     type="datetime-local"
                                     id="start_at"
@@ -43,7 +43,7 @@
                                 <x-input-error for="start_at" class="mt-2"/>
                             </div>
                             <div class="col-span-6 sm:col-span-4 pb-4">
-                                <x-label for="end_at" value="End Date" class="after:content-['*'] after:text-red-500"/>
+                                <x-label for="end_at" value="End time of the event" class="after:content-['*'] after:text-red-500"/>
                                 <input
                                     type="datetime-local"
                                     id="end_at"
@@ -53,28 +53,6 @@
                                     class="w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-xs mt-1 block"
                                 />
                                 <x-input-error for="end_at" class="mt-2"/>
-                            </div>
-                            <div class="col-span-6 sm:col-span-4 pb-4">
-                                <x-label for="lecture_duration" value="Lecture Duration"/>
-                                <x-input type="number"
-                                         id="lecture_duration"
-                                         name="lecture_duration"
-                                         value="30"
-                                         min="1"
-                                         class="mt-1 block w-full"
-                                />
-                                <x-input-error for="lecture_duration" class="mt-2"/>
-                            </div>
-                            <div class="col-span-6 sm:col-span-4 pb-4">
-                                <x-label for="workshop_duration" value="Workshop Duration"/>
-                                <x-input type="number"
-                                         id="workshop_duration"
-                                         name="workshop_duration"
-                                         value="90"
-                                         min="1"
-                                         class="mt-1 block w-full"
-                                />
-                                <x-input-error for="workshop_duration" class="mt-2"/>
                             </div>
                             <x-button
                                 class="mt-5 dark:bg-green-500 bg-green-500 hover:bg-green-600 dark:hover:bg-green-600 active:bg-purple-600 dark:active:bg-purple-600">

--- a/resources/views/crew/editions/show.blade.php
+++ b/resources/views/crew/editions/show.blade.php
@@ -22,7 +22,7 @@
                     <x-details-list-item label="Edition title">
                         {{ $edition->name }}
                     </x-details-list-item>
-                    <x-details-list-item label="Edition Date">
+                    <x-details-list-item label="Event Date & Time">
                         @if (!$edition->start_at || !$edition->end_at)
                             TBD
                         @else
@@ -30,12 +30,6 @@
                             —
                             {{ $edition->end_at->format('d-m-Y H:i') }}
                         @endif
-                    </x-details-list-item>
-                    <x-details-list-item label="Edition Lecture Duration">
-                        {{ $edition->lecture_duration }}
-                    </x-details-list-item>
-                    <x-details-list-item label="Edition Workshop Duration">
-                        {{ $edition->workshop_duration }}
                     </x-details-list-item>
                 </x-slot>
 

--- a/resources/views/livewire/edition/edit-edition-modal.blade.php
+++ b/resources/views/livewire/edition/edit-edition-modal.blade.php
@@ -25,7 +25,7 @@
                 </dd>
 
                 <!-- Edition Start Date -->
-                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Edition Start Date</dt>
+                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Starting time of the event</dt>
                 <dd class="sm:col-span-2">
                     <input
                         type="datetime-local"
@@ -39,7 +39,7 @@
                 </dd>
 
                 <!-- Edition End Date -->
-                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Edition End Date</dt>
+                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Ending time of the event</dt>
                 <dd class="sm:col-span-2">
                     <input
                         type="datetime-local"
@@ -49,30 +49,6 @@
                         class="w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:[color-scheme:dark] focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-xs mt-1 block"
                     />
                     @error('form.end_at') <span class="error text-red-500">{{ $message }}</span> @enderror
-                </dd>
-
-                <!-- Edition Lecture Duration -->
-                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Edition Lecture Duration</dt>
-                <dd class="sm:col-span-2">
-                    <input
-                        class="w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-xs mt-1 block"
-                        type="number"
-                        min="1"
-                        wire:model="form.lecture_duration"
-                        value="30" >
-                    @error('form.lecture_duration') <span class="error text-red-500">{{ $message }}</span> @enderror
-                </dd>
-
-                <!-- Edition Workshop Duration -->
-                <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Edition Workshop Duration</dt>
-                <dd class="sm:col-span-2">
-                    <input
-                        class="w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-xs mt-1 block"
-                        type="number"
-                        min="1"
-                        wire:model="form.workshop_duration"
-                        value="90" >
-                    @error('form.workshop_duration') <span class="error text-red-500">{{ $message }}</span> @enderror
                 </dd>
             </dl>
         </div>


### PR DESCRIPTION
# Description

This PR introduces quick fixes on the editions management to not include anymore the workshop/lecture duration due to their flexibility. Marks the fields as deprecated since first release has been already made. Also changes the labels of the `start_at` and `end_at` to make it a bit more user friendly and reduce confusion.

closes #692, #696 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## What needs to be tested

- [ ] Setup the database like it's being deployed (use ./vendor/bin/sail artisan app:setup-production) and ensure you can safely setup an edition
- [ ] Go through the motion of the conference (release a programme, etc.) make sure everything is as it should be (should be possible via the seeders)

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

