### PR TITLE
technical debt - replaced all deprecated @test

### DIFF
--- a/tests/Feature/BoothControllerTest.php
+++ b/tests/Feature/BoothControllerTest.php
@@ -12,6 +12,7 @@ use Database\Seeders\PermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
@@ -34,7 +35,7 @@ class BoothControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function index_displays_booths_to_crew()
     {
         $user = User::factory()->create();
@@ -47,7 +48,7 @@ class BoothControllerTest extends TestCase
         $response->assertViewHas('booths');
     }
 
-    /** @test */
+    #[Test]
     public function index_denies_participant_access_to_booths()
     {
         $user = User::factory()->create();
@@ -59,7 +60,7 @@ class BoothControllerTest extends TestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function create_displays_view_to_crew()
     {
         $user = User::factory()->create();
@@ -71,7 +72,7 @@ class BoothControllerTest extends TestCase
         $response->assertViewIs('crew.booths.create');
     }
 
-    /** @test */
+    #[Test]
     public function create_denies_access_to_participant()
     {
         $user = User::factory()->create();
@@ -119,7 +120,7 @@ class BoothControllerTest extends TestCase
             $this->assertNull($company->booth);
         }*/
 
-    /** @test */
+    #[Test]
     public function show_displays_correct_booth_to_crew()
     {
         $user = User::factory()->create();
@@ -133,7 +134,7 @@ class BoothControllerTest extends TestCase
         $response->assertViewHas('booth', $company->booth);
     }
 
-    /** @test */
+    #[Test]
     public function show_denies_access_to_participant()
     {
         $user = User::factory()->create();
@@ -145,7 +146,7 @@ class BoothControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function approve_updates_booth_and_redirects_to_crew()
     {
         $user = User::factory()->create();
@@ -168,7 +169,7 @@ class BoothControllerTest extends TestCase
         $this->assertEquals(1, $company->booth->is_approved);
     }
 
-    /** @test */
+    #[Test]
     public function approve_denies_action_to_participant()
     {
         $user = User::factory()->create();
@@ -185,7 +186,7 @@ class BoothControllerTest extends TestCase
         $this->assertEquals(0, $company->booth->is_approved);
     }
 
-    /** @test */
+    #[Test]
     public function destroy_deletes_and_redirects_to_crew()
     {
         $user = User::factory()->create();
@@ -199,7 +200,7 @@ class BoothControllerTest extends TestCase
         $this->assertEquals(Booth::count() + 1, $boothCount);
     }
 
-    /** @test */
+    #[Test]
     public function destroy_denies_action_to_participant()
     {
         $user = User::factory()->create();

--- a/tests/Feature/CompanyControllerTest.php
+++ b/tests/Feature/CompanyControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
@@ -31,7 +32,7 @@ class CompanyControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_view_companies_index()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -43,7 +44,7 @@ class CompanyControllerTest extends TestCase
         $response->assertViewHas('companies');
     }
 
-    /** @test */
+    #[Test]
     public function participant_cannot_view_companies_index()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -53,7 +54,7 @@ class CompanyControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_access_create_company_form()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -64,7 +65,7 @@ class CompanyControllerTest extends TestCase
         $response->assertViewIs('crew.companies.create');
     }
 
-    /** @test */
+    #[Test]
     public function participant_cannot_access_create_company_form()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -72,9 +73,7 @@ class CompanyControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function event_organizer_can_store_company_with_existing_user()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -98,9 +97,7 @@ class CompanyControllerTest extends TestCase
         $this->assertDatabaseHas('companies', ['name' => $companyData['name']]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function event_organizer_can_store_company_with_new_user()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -124,7 +121,7 @@ class CompanyControllerTest extends TestCase
         $this->assertDatabaseHas('companies', ['name' => $companyData['name']]);
     }
 
-    /** @test */
+    #[Test]
     public function participant_cannot_store_company()
     {
         $companyCount = Company::count();
@@ -148,7 +145,7 @@ class CompanyControllerTest extends TestCase
         $this->assertEquals($companyCount, Company::count());
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_receives_validation_errors_on_invalid_company_data()
     {
         $companyCount = Company::count();
@@ -176,7 +173,7 @@ class CompanyControllerTest extends TestCase
         $this->assertEquals($companyCount, Company::count());
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_view_company_details()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -189,7 +186,7 @@ class CompanyControllerTest extends TestCase
         $response->assertViewHas('company', $company);
     }
 
-    /** @test */
+    #[Test]
     public function participant_cannot_view_company_details()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -200,7 +197,7 @@ class CompanyControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_approve_company()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -222,7 +219,7 @@ class CompanyControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_reject_company()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -241,7 +238,7 @@ class CompanyControllerTest extends TestCase
         $this->assertDatabaseMissing('companies', ['name' => $company->name]);
     }
 
-    /** @test */
+    #[Test]
     public function participant_cannot_approve_or_reject_company()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -255,7 +252,7 @@ class CompanyControllerTest extends TestCase
         $this->assertEquals(ApprovalStatus::AWAITING_APPROVAL->value, $company->approval_status);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_delete_company()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -269,7 +266,7 @@ class CompanyControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function participant_cannot_delete_company()
     {
         $user = User::factory()->create()->assignRole('participant');

--- a/tests/Feature/ContactTest.php
+++ b/tests/Feature/ContactTest.php
@@ -5,6 +5,7 @@ namespace Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Mail\ContactUs;
 
@@ -20,7 +21,7 @@ class ContactTest extends TestCase
         Artisan::call('admin:sync-permissions');
     }
 
-    /** @test */
+    #[Test]
     public function test_that_user_successfully_sends_a_question(): void
     {
         # Arrange
@@ -43,7 +44,7 @@ class ContactTest extends TestCase
         Mail::assertSent(ContactUs::class);
     }
 
-    /** @test */
+    #[Test]
     public function test_that_it_requires_all_fields_to_be_filled(): void
     {
         # Act
@@ -53,7 +54,7 @@ class ContactTest extends TestCase
         $response->assertSessionHasErrors(['name', 'email', 'subject', 'message']);
     }
 
-    /** @test */
+    #[Test]
     public function test_that_email_field_must_be_valid(): void
     {
         # Arrange
@@ -71,7 +72,7 @@ class ContactTest extends TestCase
         $response->assertSessionHasErrors('email');
     }
 
-    /** @test */
+    #[Test]
     public function test_that_subject_must_be_from_allowed_options(): void
     {
         # Arrange

--- a/tests/Feature/RoomControllerTest.php
+++ b/tests/Feature/RoomControllerTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Activitylog\Models\Activity;
 use Tests\TestCase;
 
@@ -31,7 +32,7 @@ class RoomControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function index_displays_rooms_to_crew()
     {
         $user = User::factory()->create();
@@ -44,7 +45,7 @@ class RoomControllerTest extends TestCase
         $response->assertViewHas('rooms');
     }
 
-    /** @test */
+    #[Test]
     public function index_denies_participant_access_to_rooms()
     {
         $user = User::factory()->create();
@@ -56,7 +57,7 @@ class RoomControllerTest extends TestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function create_displays_view_to_rooms()
     {
         $user = User::factory()->create();
@@ -68,7 +69,7 @@ class RoomControllerTest extends TestCase
         $response->assertViewIs('crew.rooms.create');
     }
 
-    /** @test */
+    #[Test]
     public function create_denies_access_to_participant()
     {
         $user = User::factory()->create();
@@ -79,7 +80,7 @@ class RoomControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function store_saves_and_redirects_to_crew()
     {
         $user = User::factory()->create();
@@ -95,7 +96,7 @@ class RoomControllerTest extends TestCase
         $this->assertDatabaseHas('rooms', $data);
     }
 
-    /** @test */
+    #[Test]
     public function store_denies_action_to_participant()
     {
         $user = User::factory()->create();
@@ -112,7 +113,7 @@ class RoomControllerTest extends TestCase
         $this->assertNull($company->booth);
     }
 
-    /** @test */
+    #[Test]
     public function show_displays_correct_room_to_crew()
     {
         $user = User::factory()->create();
@@ -127,7 +128,7 @@ class RoomControllerTest extends TestCase
         $response->assertViewHas('room', $room);
     }
 
-    /** @test */
+    #[Test]
     public function show_denies_access_to_participant()
     {
         $user = User::factory()->create();
@@ -140,7 +141,7 @@ class RoomControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function destroy_deletes_and_redirects_to_crew()
     {
         $user = User::factory()->create();
@@ -156,7 +157,7 @@ class RoomControllerTest extends TestCase
         $this->assertEquals(Room::count() + 1, $roomCount);
     }
 
-    /** @test */
+    #[Test]
     public function destroy_denies_action_to_participant()
     {
         $user = User::factory()->create();

--- a/tests/Feature/SponsorshipControllerTest.php
+++ b/tests/Feature/SponsorshipControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Activitylog\Contracts\Activity;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
@@ -31,7 +32,7 @@ class SponsorshipControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_view_sponsorships_index()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -43,7 +44,7 @@ class SponsorshipControllerTest extends TestCase
         $response->assertViewHas('companies');
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_view_sponsorships_index_without_permission()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -53,7 +54,7 @@ class SponsorshipControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_access_create_sponsorship_form()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -66,7 +67,7 @@ class SponsorshipControllerTest extends TestCase
         $response->assertViewHas('tiers');
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_access_create_sponsorship_form_without_permission()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -76,7 +77,7 @@ class SponsorshipControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_store_sponsorship()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -97,7 +98,7 @@ class SponsorshipControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_view_sponsorship()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -110,7 +111,7 @@ class SponsorshipControllerTest extends TestCase
         $response->assertViewHas('company', $company);
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_show_nonexistent_sponsorship()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -120,7 +121,7 @@ class SponsorshipControllerTest extends TestCase
         $response->assertStatus(404);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_approve_sponsorship()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -136,7 +137,7 @@ class SponsorshipControllerTest extends TestCase
         $this->assertEquals(ApprovalStatus::APPROVED->value, $company->refresh()->sponsorship_approval_status);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_reject_sponsorship()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -152,7 +153,7 @@ class SponsorshipControllerTest extends TestCase
         $this->assertEquals(ApprovalStatus::NOT_REQUESTED->value, $company->refresh()->sponsorship_approval_status);
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_approve_or_reject_sponsorship_without_permission()
     {
         $user = User::factory()->create()->assignRole('participant');
@@ -165,7 +166,7 @@ class SponsorshipControllerTest extends TestCase
         $this->assertDatabaseHas('companies', ['id' => $company->id]);
     }
 
-    /** @test */
+    #[Test]
     public function event_organizer_can_delete_sponsorship()
     {
         $user = User::factory()->create()->assignRole('event organizer');
@@ -177,7 +178,7 @@ class SponsorshipControllerTest extends TestCase
         $this->assertNull($company->refresh()->sponsorship_id);
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_delete_sponsorship_without_permission()
     {
         $user = User::factory()->create()->assignRole('participant');


### PR DESCRIPTION
# Description

previously the unit tests contained  /** @test */ comments, causing depricate warnings. the fix is replacing them with #[Test], which removes the warnings

closes #628

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] running the tests to see if there are still any warnings about using /** @test */

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

