### PR TITLE
Feature - Colours preview in presentation types

### DIFF
--- a/app/Livewire/PresentationType/CreateEditModal.php
+++ b/app/Livewire/PresentationType/CreateEditModal.php
@@ -13,7 +13,7 @@ class CreateEditModal extends ModalComponent
 {
     public PresentationType $presentationType;
 
-    public ?int $presentationTypeId;
+    public ?int $presentationTypeId = null;
 
     public int $editionId;
 
@@ -138,8 +138,10 @@ class CreateEditModal extends ModalComponent
         $this->colourUsedBy = '';
         $usedBy = PresentationType::where('colour', $value)->first();
 
-        if ($usedBy) {
+        if ($usedBy && $this->presentationTypeId) {
             $this->colourUsedBy = $usedBy->id != $this->presentationType->id ? $usedBy->name : '';
+        } elseif ($usedBy) {
+            $this->colourUsedBy = $usedBy->name;
         }
     }
 

--- a/resources/views/livewire/presentation-type/create-edit-modal.blade.php
+++ b/resources/views/livewire/presentation-type/create-edit-modal.blade.php
@@ -40,6 +40,18 @@
                         </span>
                     @endif
                 </dd>
+                @if($this->colour)
+                    <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Preview</dt>
+                    <dd class="sm:col-span-2">
+                        <div class="rounded-md h-12 border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 grid grid-cols-3">
+                            <div class="w-full h-full bg-{{lcfirst($this->colour)}}-200 flex justify-center text-center items-center">Sample</div>
+                            <div class="w-full h-full bg-{{lcfirst($this->colour)}}-300 flex justify-center text-center items-center">Sample</div>
+                            <div class="w-full h-full bg-{{lcfirst($this->colour)}}-400/90 text-{{lcfirst($this->colour)}}-400 flex justify-center text-center items-center">
+                                Sample
+                            </div>
+                        </div>
+                    </dd>
+                @endif
                 <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Duration</dt>
                 <dd class="sm:col-span-2">
                     <input


### PR DESCRIPTION
# Description

This PR introduces a quick feature that allows the mod to preview the colours they select for the presentation

closes #749 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What needs to be tested

- [ ] When you create new presentation type the preview should be hidden until you first select a colour and then it should appear
- [ ] When you edit an already existing presentation type the preview should show the current colour and reflect changes if you change the colour

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

